### PR TITLE
feat(vscode): 支持以 VS Code 扩展形式编辑和阅读 Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@
 | ------- | -------------------------------- | ----------------------- |
 | Windows | C# + .NET 10 WinForms + WebView2 | `apps/windows/MarkLeaf` |
 | macOS   | Swift + AppKit + WKWebView       | `apps/macos`            |
+| VS Code 扩展 | TypeScript + CustomTextEditorProvider + Webview | `apps/vscode` |
 
 
-两个平台共享同一套编辑器前端与样式，应用则用平台原生方法实现。
+三个宿主共享编辑内核与排版样式。VS Code 扩展使用现有 VS Code 运行环境，不引入 Electron 依赖或独立桌面壳。安装扩展后，Markdown 文件默认以 MarkLeaf 渲染视图打开，支持阅读与可视化编辑、保存、撤销重做，以及原生源码并排编辑；详见 [扩展说明](./apps/vscode/README.md)。
 
 ## 项目结构
 
@@ -83,6 +84,7 @@ markleaf/
 │   ├── windows/                  # Windows 原生应用（C# WinForms）
 │   │   ├── MarkLeaf/             #   主程序（.NET 10 + WebView2）
 │   │   └── setup/                #   Inno Setup 安装器
+│   ├── vscode/                   # VS Code Markdown 阅读与编辑扩展（TypeScript）
 │   └── macos/                    # macOS 原生应用（Swift AppKit + WKWebView）
 │       ├── Sources/MarkLeaf/     #   主程序
 │       ├── Changelog/            #   产品更新日志（四语言）
@@ -110,6 +112,16 @@ apps/windows（C# WinForms）        apps/macos（Swift AppKit）
 ```
 
 ## 构建与运行
+
+### VS Code 扩展
+
+```bash
+pnpm --dir packages/editor-web install --frozen-lockfile
+pnpm --dir apps/vscode install --frozen-lockfile
+pnpm package:vscode                # artifacts/markleaf-vscode-0.1.0.vsix
+```
+
+在 VS Code 中安装生成的 VSIX 后，新打开的 `.md`、`.markdown` 文件默认进入 MarkLeaf 渲染视图。已有源码标签可通过 **Reopen Editor With… → MarkLeaf** 或 **MarkLeaf: Open Markdown** 切换；已配置其他默认编辑器时，可通过 **Configure default editor for…** 选择 MarkLeaf。使用 **Ctrl+Shift+V**（macOS 为 **Cmd+Shift+V**）在原生源码与 MarkLeaf 渲染视图之间切换。可视化编辑允许现有序列化器规范化 Markdown 格式，阅读不会回写；详见[使用和保真边界](./apps/vscode/README.md)。
 
 ### Web 前端编辑器
 

--- a/apps/vscode/.vscodeignore
+++ b/apps/vscode/.vscodeignore
@@ -1,0 +1,5 @@
+**/*
+!package.json
+!README.md
+!dist/**
+!dist/webview/.vite/manifest.json

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -1,0 +1,65 @@
+# MarkLeaf for VS Code
+
+在 VS Code 中阅读和可视化编辑 Markdown，复用 MarkLeaf 的 Tiptap/ProseMirror 编辑内核、KaTeX、Mermaid 和排版样式。扩展由 TypeScript 编写，运行时使用 VS Code 提供的 API 与 Webview；没有 Electron 依赖或独立桌面壳。
+
+## 安装和打开
+
+本地构建得到 `artifacts/markleaf-vscode-0.1.0.vsix` 后，在 VS Code 的扩展菜单选择 **Install from VSIX…**，或执行：
+
+```bash
+code --install-extension artifacts/markleaf-vscode-0.1.0.vsix
+```
+
+安装并启用扩展后，新打开的 `.md` 或 `.markdown` 文件默认进入 MarkLeaf 渲染视图，可直接阅读和可视化编辑。已打开的源码标签可以通过 **Reopen Editor With… → MarkLeaf** 或 **Ctrl/Cmd+Shift+V** 切换，也可以从资源管理器右键选择 **MarkLeaf: Open Markdown**。
+
+MarkLeaf 使用 VS Code 的默认自定义编辑器声明。若已为 Markdown 指定了其他默认编辑器，或安装了多个默认 Markdown 编辑器，可在 **Reopen Editor With… → Configure default editor for…** 中选择 **MarkLeaf**。需要恢复默认源码打开方式时，在同一位置选择 **Text Editor**；扩展遵循 VS Code 的编辑器关联设置。
+
+## 使用
+
+- **阅读 / 编辑**：工具栏切换模式。打开文档和切换模式不会触发 Markdown 回写。
+- **格式**：粗体、斜体、删除线、行内代码；“格式…”提供标题、列表、任务列表、引用、代码块、提示框、表格、公式和 Mermaid 插入，以及表格行列操作。
+- **保存**：使用 VS Code 的保存命令、自动保存或 `Ctrl/Cmd+S`。底部“已同步到 VS Code”表示编辑已进入文本缓冲区；是否已写入磁盘以 VS Code 的未保存标记为准。
+- **撤销 / 重做**：使用 `Ctrl/Cmd+Z`、`Ctrl/Cmd+Shift+Z`，或工具栏按钮，由 VS Code 文档历史管理。连续输入按提交批次撤销；中文组合输入在提交时同步。
+- **源码 / 并排**：打开 VS Code 原生 Markdown 编辑器，共用同一份 `TextDocument`。源码修改会更新可视化视图。
+- **快捷切换源码 / 渲染**：`Ctrl+Shift+V`（macOS 为 `Cmd+Shift+V`）在原生 Markdown 源码与 MarkLeaf 渲染视图间双向切换；切回源码前等待编辑同步。此绑定在 Markdown 编辑场景中接管原生预览快捷键，可在 VS Code 键盘快捷方式中调整 `MarkLeaf: Toggle Source / Rendered View`；原生预览命令仍可通过命令面板使用。
+- **图片**：展示文档中已有的本地图片和 HTTP/HTTPS 图片。“图片”可以插入相对路径或 URL；展示用的 Webview 地址不会写回 Markdown。本地资源范围为文档所在目录和当前工作区。独立文件引用目录外的图片时，请打开包含它们的工作区。
+- **链接**：阅读模式直接单击，编辑模式按住 `Ctrl`（macOS 为 `Cmd`）单击。支持网页、本地文件和文内标题定位。
+- **查找**：使用 VS Code Webview 的查找功能（`Ctrl/Cmd+F`）。
+
+公式、图表和代码复用已有编辑控件。界面颜色跟随 VS Code，字号和正文最大宽度可在设置中调整：
+
+| 设置 | 默认值 | 含义 |
+| --- | --- | --- |
+| `markleaf.defaultMode` | `edit` | 新打开视图的初始模式：`edit` 或 `read` |
+| `markleaf.fontSize` | `16` | 正文字号，10–32 px |
+| `markleaf.maxWidth` | `820` | 正文最大宽度，320–1600 px |
+
+## 文档同步与格式边界
+
+VS Code 的 `TextDocument` 是文档事实源，负责保存、未保存标记和编辑历史。Webview 同时只提交一次编辑，收到版本确认后再提交期间累积的新内容；自身编辑确认不重建编辑器。若其他视图同时修改文件，过期编辑不会覆盖新版本，未同步内容会保留在 MarkLeaf，并提供“将未同步内容打开为草稿”。草稿由 VS Code 打开后，MarkLeaf 重新加载文件当前内容；请在源码中合并草稿。
+
+仅打开和阅读不会改动源文件。实际可视化编辑会经过 Markdown 解析和序列化，可能规范化列表标记、空行、强调或其他源码格式；保留文档的换行符类型和既有末尾换行，不承诺逐字节保真。编辑范围为共享内核支持的段落、标题、列表、任务、引用、代码、表格、图片、链接、YAML front matter、脚注、公式、Mermaid 和提示框。MDX、自定义 Markdown 插件语法或需要保留任意原始 HTML 的文档，请使用源码编辑器。
+
+首版允许每个文件一个 MarkLeaf 可视化视图，并可与原生源码并排。Webview 暂时保留隐藏视图的上下文，以保护未完成输入。日常保存会等待同步；VS Code 退出时可能跳过保存参与者，因此关闭窗口前应确认同步完成，冲突内容应先打开为草稿。
+
+当前交付目标是桌面 VS Code。浏览器版没有扩展入口；远程 URI 使用 VS Code 资源 API 解析，但 Windows、Linux 和远程工作区需要分别运行验证。图片粘贴、拖入文件后的复制策略、PDF、打印和长图导出未纳入首版。
+
+## 开发与构建
+
+从仓库根目录执行，Node.js 22.12+，使用项目指定的 pnpm：
+
+```bash
+pnpm --dir packages/editor-web install --frozen-lockfile
+pnpm --dir apps/vscode install --frozen-lockfile
+pnpm build:vscode
+pnpm test:editor-web
+pnpm package:vscode
+```
+
+开发运行可使用已有 VS Code，无需安装额外桌面运行时：
+
+```bash
+code --new-window --extensionDevelopmentPath="$PWD/apps/vscode" path/to/document.md
+```
+
+`packages/editor-web/src/vscode.ts` 是扩展专用前端入口；`apps/vscode/src/extension.ts` 是 VS Code 文档适配层。原生 Windows/macOS 入口继续使用现有 `main.ts` 和原生宿主协议。扩展构建输出到 `apps/vscode/dist`，原生前端仍输出到 `packages/editor-web/dist`。

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "markleaf",
+  "displayName": "MarkLeaf",
+  "description": "Read and visually edit Markdown with MarkLeaf, using VS Code documents and source editing.",
+  "version": "0.1.0",
+  "publisher": "markleaf",
+  "license": "MIT",
+  "engines": { "vscode": "^1.95.0" },
+  "categories": ["Other"],
+  "keywords": ["markdown", "wysiwyg", "preview", "mermaid", "katex"],
+  "repository": { "type": "git", "url": "https://github.com/zhuanshunjishi2017/markleaf.git" },
+  "main": "./dist/extension.js",
+  "extensionKind": ["workspace"],
+  "capabilities": { "untrustedWorkspaces": { "supported": true } },
+  "contributes": {
+    "customEditors": [{
+      "viewType": "markleaf.editor",
+      "displayName": "MarkLeaf",
+      "selector": [{ "filenamePattern": "*.md" }, { "filenamePattern": "*.markdown" }],
+      "priority": "default"
+    }],
+    "commands": [
+      { "command": "markleaf.open", "title": "MarkLeaf: Open Markdown" },
+      { "command": "markleaf.toggleEditor", "title": "MarkLeaf: Toggle Source / Rendered View" },
+      { "command": "markleaf.openSource", "title": "MarkLeaf: Open Source", "icon": "$(code)" },
+      { "command": "markleaf.openSourceBeside", "title": "MarkLeaf: Open Source to the Side", "icon": "$(split-horizontal)" }
+    ],
+    "keybindings": [{
+      "command": "markleaf.toggleEditor",
+      "key": "ctrl+shift+v",
+      "mac": "cmd+shift+v",
+      "when": "editorTextFocus && editorLangId == markdown || webviewFocus && activeCustomEditorId == markleaf.editor"
+    }],
+    "menus": {
+      "explorer/context": [{ "command": "markleaf.open", "when": "resourceExtname == .md || resourceExtname == .markdown", "group": "open@10" }],
+      "editor/title": [
+        { "command": "markleaf.open", "when": "editorLangId == markdown && activeCustomEditorId != markleaf.editor", "group": "navigation" },
+        { "command": "markleaf.openSource", "when": "activeCustomEditorId == markleaf.editor", "group": "navigation" },
+        { "command": "markleaf.openSourceBeside", "when": "activeCustomEditorId == markleaf.editor", "group": "navigation" }
+      ]
+    },
+    "configuration": {
+      "title": "MarkLeaf",
+      "properties": {
+        "markleaf.defaultMode": { "type": "string", "scope": "resource", "enum": ["edit", "read"], "default": "edit", "description": "Initial mode for newly opened MarkLeaf editors." },
+        "markleaf.fontSize": { "type": "number", "scope": "resource", "default": 16, "minimum": 10, "maximum": 32, "description": "Document font size in pixels." },
+        "markleaf.maxWidth": { "type": "number", "scope": "resource", "default": 820, "minimum": 320, "maximum": 1600, "description": "Maximum document width in pixels." }
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsc --noEmit && node scripts/build.mjs",
+    "package": "vsce package --no-dependencies --skip-license --out ../../artifacts/markleaf-vscode-0.1.0.vsix"
+  },
+  "devDependencies": {
+    "@types/node": "24.10.1",
+    "@types/vscode": "1.95.0",
+    "@vscode/vsce": "3.6.2",
+    "esbuild": "0.25.12",
+    "typescript": "5.9.3"
+  }
+}

--- a/apps/vscode/pnpm-lock.yaml
+++ b/apps/vscode/pnpm-lock.yaml
@@ -1,0 +1,2730 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: 24.10.1
+        version: 24.10.1
+      '@types/vscode':
+        specifier: 1.95.0
+        version: 1.95.0
+      '@vscode/vsce':
+        specifier: 3.6.2
+        version: 3.6.2
+      esbuild:
+        specifier: 0.25.12
+        version: 0.25.12
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@azu/format-text@1.0.2':
+    resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
+
+  '@azu/style-format@1.0.1':
+    resolution: {integrity: sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==}
+
+  '@azure/abort-controller@2.2.0':
+    resolution: {integrity: sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-auth@1.11.0':
+    resolution: {integrity: sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-client@1.11.1':
+    resolution: {integrity: sha512-2QygG2F76ZpMP2eMztiJvAiFMu71M9rDeU7vO/QKg5Css7MgM4frUOslFjhVjRhbGaCNPtz/S8M6y46/fFKVuQ==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-process@1.0.0':
+    resolution: {integrity: sha512-/shnJ+ooO8WPxDhPEeI/2oRQuubn16gZ6CvlbpWbEswZfzwI9tI/sMAHmF3x1LuQ9yZYXfLW3TjzGMLEC5blKg==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-rest-pipeline@1.25.0':
+    resolution: {integrity: sha512-bMs8ekJLjX8wPV+9IPBges1SLPyuDtE9g5gLDWOpxzKcoOFQnpLGkbcT1tdw3FaAmDS1gnPmMmJ6y/T5B96kIA==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-tracing@1.4.0':
+    resolution: {integrity: sha512-eGwxD0AtncrxeBM4tG8R55Pc3rdX1hNW2WibJAgYpCVA6E93mvvVH+LcssoVjOBrSKWS55yEIHsk0X8ctHmfOQ==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-util@1.14.0':
+    resolution: {integrity: sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/identity@4.13.2':
+    resolution: {integrity: sha512-NXL2/pCJctLxgw8bvrwwgge743kEq8LBT+O1pmV0vyUwetzFPH9auP6jhkU/cgZCPPtWoewAe3ncaGCgPo07fA==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/logger@1.4.0':
+    resolution: {integrity: sha512-rbAE25KUfjU/s3XHUdJgceoCP5dEOpMx85J04kF+QMdta73XkuG9JGHHinch+XIoKpBdqljin+KqURpJriSzLA==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/msal-browser@5.21.0':
+    resolution: {integrity: sha512-80OcuXDErmcEDAIH9pBtSqBsed2sPT/IWmbG3xHLoPMl5zc8TINd6SlJAbVSmN5huGa3xGAg5qR7VnpaIEK0Zw==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-common@16.13.0':
+    resolution: {integrity: sha512-rOAy0KUcyBbdwVJ+f3uPpthXatFLLZN+/KWAsTLzk1aB23Xl9DRmmXYwSvBFOZyXj4jUQQ5FKxxRkhAFW1fOow==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-common@16.14.0':
+    resolution: {integrity: sha512-A4rb55hI86Q9tBl/+jBj7TMz7iX2RFgQs/nExFzcAtoI/BFRVdaH5SL/MivrYD7qvweMpN8AgVvVMHV8UBYxew==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-node@5.6.0':
+    resolution: {integrity: sha512-uFY9NxrWHw8PwZx7gAX6PDn+9vdfS05+levc/kwkx77IkjfaldnQbbcQzzDIZ5Hq5Zdr6/z92oAIoRWKp6MnOA==}
+    engines: {node: '>=20'}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@secretlint/config-creator@10.2.2':
+    resolution: {integrity: sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/config-loader@10.2.2':
+    resolution: {integrity: sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/core@10.2.2':
+    resolution: {integrity: sha512-6rdwBwLP9+TO3rRjMVW1tX+lQeo5gBbxl1I5F8nh8bgGtKwdlCMhMKsBWzWg1ostxx/tIG7OjZI0/BxsP8bUgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/formatter@10.2.2':
+    resolution: {integrity: sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/node@10.2.2':
+    resolution: {integrity: sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/profiler@10.2.2':
+    resolution: {integrity: sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==}
+
+  '@secretlint/resolver@10.2.2':
+    resolution: {integrity: sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==}
+
+  '@secretlint/secretlint-formatter-sarif@10.2.2':
+    resolution: {integrity: sha512-ojiF9TGRKJJw308DnYBucHxkpNovDNu1XvPh7IfUp0A12gzTtxuWDqdpuVezL7/IP8Ua7mp5/VkDMN9OLp1doQ==}
+
+  '@secretlint/secretlint-rule-no-dotenv@10.2.2':
+    resolution: {integrity: sha512-KJRbIShA9DVc5Va3yArtJ6QDzGjg3PRa1uYp9As4RsyKtKSSZjI64jVca57FZ8gbuk4em0/0Jq+uy6485wxIdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/secretlint-rule-preset-recommend@10.2.2':
+    resolution: {integrity: sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/source-creator@10.2.2':
+    resolution: {integrity: sha512-h6I87xJfwfUTgQ7irWq7UTdq/Bm1RuQ/fYhA3dtTIAop5BwSFmZyrchph4WcoEvbN460BWKmk4RYSvPElIIvxw==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/types@10.2.2':
+    resolution: {integrity: sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==}
+    engines: {node: '>=20.0.0'}
+
+  '@sindresorhus/merge-streams@2.3.0':
+    resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
+    engines: {node: '>=18'}
+
+  '@textlint/ast-node-types@15.8.0':
+    resolution: {integrity: sha512-5CiH9COYmovWmExQgs7763DzX6Gy9zjkjJ7JxCC95wyTcjwQn/8poNF6fv3qzRlmx8CRRde8DHr9FcgAAiPzgw==}
+
+  '@textlint/linter-formatter@15.8.0':
+    resolution: {integrity: sha512-+oU3A235NATv6Lzi4xa4kJ65PuNJlIxesaO4AvDhDWA9FWm7y4XKWaoQCW1esgaQQ6dwnUiFKArQ8TcJ86mC4w==}
+    engines: {node: '>=20.18.0'}
+
+  '@textlint/module-interop@15.8.0':
+    resolution: {integrity: sha512-rt+OR1WYGoLOY8HkA/aBPrqufF6yUUEsKEAh7XohTsT3lp9IyZFT6zOIbjul9P4FAzsmSPkcrYjVx3Bz/IUfkg==}
+
+  '@textlint/resolver@15.8.0':
+    resolution: {integrity: sha512-E88tzfX3K8Jykk+38aJ9cy8RquD8ABVOPTO2rFEESq0wcg8x6/ypdAS8ZgR7OKiGqlRF0hkO/m5PbQwVfKM3VA==}
+
+  '@textlint/types@15.8.0':
+    resolution: {integrity: sha512-Anhc6y5736YIsvqae0U6k0YmB2M/QVHkEeOv2aydAn/WIkdI69dCOiDbe3/+RagS3qstFTSFWJzNRA2lUjv19w==}
+
+  '@types/node@24.10.1':
+    resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
+
+  '@types/normalize-package-data@2.4.4':
+    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/sarif@2.1.7':
+    resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
+
+  '@types/vscode@1.95.0':
+    resolution: {integrity: sha512-0LBD8TEiNbet3NvWsmn59zLzOFu/txSlGxnv5yAFHCrhG9WvAnR3IvfHzMOs2aeWqgvNjq9pO99IUw8d3n+unw==}
+
+  '@typespec/ts-http-runtime@0.3.9':
+    resolution: {integrity: sha512-edSdeAqkdxBVzA1yL1LrLCml1YjyCVvPMtMqJpbF+6K609tHe8V6sQUzFQSGcYNhcuhOceZtjvN32+mpIth30A==}
+    engines: {node: '>=22.0.0'}
+
+  '@vscode/vsce-sign-alpine-arm64@2.0.6':
+    resolution: {integrity: sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==}
+    cpu: [arm64]
+    os: [alpine]
+
+  '@vscode/vsce-sign-alpine-x64@2.0.6':
+    resolution: {integrity: sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==}
+    cpu: [x64]
+    os: [alpine]
+
+  '@vscode/vsce-sign-darwin-arm64@2.0.6':
+    resolution: {integrity: sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@vscode/vsce-sign-darwin-x64@2.0.6':
+    resolution: {integrity: sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@vscode/vsce-sign-linux-arm64@2.0.6':
+    resolution: {integrity: sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@vscode/vsce-sign-linux-arm@2.0.6':
+    resolution: {integrity: sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@vscode/vsce-sign-linux-x64@2.0.6':
+    resolution: {integrity: sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@vscode/vsce-sign-win32-arm64@2.0.6':
+    resolution: {integrity: sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@vscode/vsce-sign-win32-x64@2.0.6':
+    resolution: {integrity: sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@vscode/vsce-sign@2.1.0':
+    resolution: {integrity: sha512-9AQrqazrBgTgRSuwleLVXUrIUphY02/SFCh2TKYoLV/xifJAdblhdmEmw5gUrYSPQ3sRwNs9iyCMD14sATEE6g==}
+
+  '@vscode/vsce@3.6.2':
+    resolution: {integrity: sha512-gvBfarWF+Ii20ESqjA3dpnPJpQJ8fFJYtcWtjwbRADommCzGg1emtmb34E+DKKhECYvaVyAl+TF9lWS/3GSPvg==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  azure-devops-node-api@12.5.0:
+    resolution: {integrity: sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  binaryextensions@6.11.0:
+    resolution: {integrity: sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==}
+    engines: {node: '>=4'}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  boundary@2.0.0:
+    resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
+
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  cockatiel@3.2.1:
+    resolution: {integrity: sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==}
+    engines: {node: '>=16'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.1:
+    resolution: {integrity: sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  editions@6.22.0:
+    resolution: {integrity: sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==}
+    engines: {ecmascript: '>= es5', node: '>=4'}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
+
+  fastq@1.20.3:
+    resolution: {integrity: sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs-extra@11.4.0:
+    resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
+    engines: {node: '>=14.14'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  globby@14.1.0:
+    resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
+    engines: {node: '>=18'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hosted-git-info@4.1.0:
+    resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
+    engines: {node: '>=10'}
+
+  hosted-git-info@7.0.2:
+    resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore@7.0.9:
+    resolution: {integrity: sha512-brTTsvFRt5C1gGHtPst/281UjPD5t9fBqbgoMPlVWy11ZLTPfu7HxK4ZYqO9H7o/yC9rSTCI85EaQ4OoY12qYw==}
+    engines: {node: '>= 4'}
+
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
+    engines: {node: '>=18'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istextorbinary@9.5.0:
+    resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
+    engines: {node: '>=4'}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
+    hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  keytar@7.9.0:
+    resolution: {integrity: sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==}
+
+  leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
+
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
+  markdown-it@14.3.1:
+    resolution: {integrity: sha512-4Ej49aYTDFIQ+uBkfX8GBvJGccoARxxPep+7aWTs55ozbjQJpW9M26Fe53vnGgvLeVzva/amzjQQaQu9w0vMhA==}
+    hasBin: true
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@0.0.8:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  node-abi@3.96.0:
+    resolution: {integrity: sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==}
+    engines: {node: '>=10'}
+
+  node-addon-api@4.3.0:
+    resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
+
+  node-sarif-builder@3.4.0:
+    resolution: {integrity: sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==}
+    engines: {node: '>=20'}
+
+  normalize-package-data@6.0.2:
+    resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
+  p-map@7.0.7:
+    resolution: {integrity: sha512-VaWRu2i4FJNRtiRWCuuQRgfQ1B7a6+gMSrO+3j0EQi/k0ULfS9kosRxGoiqwzIjZTDI02tGfk5mXXltLg6QtfQ==}
+    engines: {node: '>=18'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
+
+  parse-semver@1.1.1:
+    resolution: {integrity: sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  path-type@6.0.0:
+    resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
+    engines: {node: '>=18'}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  pluralize@2.0.0:
+    resolution: {integrity: sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==}
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
+    engines: {node: '>=0.6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  rc-config-loader@4.1.4:
+    resolution: {integrity: sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  read-pkg@9.0.1:
+    resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
+    engines: {node: '>=18'}
+
+  read@1.0.7:
+    resolution: {integrity: sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==}
+    engines: {node: '>=0.8'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sax@1.6.1:
+    resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
+    engines: {node: '>=11.0.0'}
+
+  secretlint@10.2.2:
+    resolution: {integrity: sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
+
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  structured-source@4.0.0:
+    resolution: {integrity: sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
+
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  terminal-link@4.0.0:
+    resolution: {integrity: sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==}
+    engines: {node: '>=18'}
+
+  text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  textextensions@6.11.0:
+    resolution: {integrity: sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==}
+    engines: {node: '>=4'}
+
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
+  typed-rest-client@1.8.11:
+    resolution: {integrity: sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.29.1:
+    resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
+    engines: {node: '>=20.18.1'}
+
+  unicorn-magic@0.1.0:
+    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
+  url-join@4.0.1:
+    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  version-range@4.15.0:
+    resolution: {integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==}
+    engines: {node: '>=4'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
+  xml2js@0.5.0:
+    resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  yazl@2.5.1:
+    resolution: {integrity: sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==}
+
+snapshots:
+
+  '@azu/format-text@1.0.2': {}
+
+  '@azu/style-format@1.0.1':
+    dependencies:
+      '@azu/format-text': 1.0.2
+
+  '@azure/abort-controller@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-auth@1.11.0':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-util': 1.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-client@1.11.1':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-process@1.0.0': {}
+
+  '@azure/core-rest-pipeline@1.25.0':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      '@typespec/ts-http-runtime': 0.3.9
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-tracing@1.4.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-util@1.14.0':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@typespec/ts-http-runtime': 0.3.9
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/identity@4.13.2':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-client': 1.11.1
+      '@azure/core-process': 1.0.0
+      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      '@azure/msal-browser': 5.21.0
+      '@azure/msal-node': 5.6.0
+      open: 10.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/logger@1.4.0':
+    dependencies:
+      '@typespec/ts-http-runtime': 0.3.9
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/msal-browser@5.21.0':
+    dependencies:
+      '@azure/msal-common': 16.14.0
+
+  '@azure/msal-common@16.13.0': {}
+
+  '@azure/msal-common@16.14.0': {}
+
+  '@azure/msal-node@5.6.0':
+    dependencies:
+      '@azure/msal-common': 16.13.0
+      jsonwebtoken: 9.0.3
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@isaacs/cliui@9.0.0': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.3
+
+  '@secretlint/config-creator@10.2.2':
+    dependencies:
+      '@secretlint/types': 10.2.2
+
+  '@secretlint/config-loader@10.2.2':
+    dependencies:
+      '@secretlint/profiler': 10.2.2
+      '@secretlint/resolver': 10.2.2
+      '@secretlint/types': 10.2.2
+      ajv: 8.20.0
+      debug: 4.4.3
+      rc-config-loader: 4.1.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@secretlint/core@10.2.2':
+    dependencies:
+      '@secretlint/profiler': 10.2.2
+      '@secretlint/types': 10.2.2
+      debug: 4.4.3
+      structured-source: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@secretlint/formatter@10.2.2':
+    dependencies:
+      '@secretlint/resolver': 10.2.2
+      '@secretlint/types': 10.2.2
+      '@textlint/linter-formatter': 15.8.0
+      '@textlint/module-interop': 15.8.0
+      '@textlint/types': 15.8.0
+      chalk: 5.6.2
+      debug: 4.4.3
+      pluralize: 8.0.0
+      strip-ansi: 7.2.0
+      table: 6.9.0
+      terminal-link: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@secretlint/node@10.2.2':
+    dependencies:
+      '@secretlint/config-loader': 10.2.2
+      '@secretlint/core': 10.2.2
+      '@secretlint/formatter': 10.2.2
+      '@secretlint/profiler': 10.2.2
+      '@secretlint/source-creator': 10.2.2
+      '@secretlint/types': 10.2.2
+      debug: 4.4.3
+      p-map: 7.0.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@secretlint/profiler@10.2.2': {}
+
+  '@secretlint/resolver@10.2.2': {}
+
+  '@secretlint/secretlint-formatter-sarif@10.2.2':
+    dependencies:
+      node-sarif-builder: 3.4.0
+
+  '@secretlint/secretlint-rule-no-dotenv@10.2.2':
+    dependencies:
+      '@secretlint/types': 10.2.2
+
+  '@secretlint/secretlint-rule-preset-recommend@10.2.2': {}
+
+  '@secretlint/source-creator@10.2.2':
+    dependencies:
+      '@secretlint/types': 10.2.2
+      istextorbinary: 9.5.0
+
+  '@secretlint/types@10.2.2': {}
+
+  '@sindresorhus/merge-streams@2.3.0': {}
+
+  '@textlint/ast-node-types@15.8.0': {}
+
+  '@textlint/linter-formatter@15.8.0':
+    dependencies:
+      '@azu/format-text': 1.0.2
+      '@azu/style-format': 1.0.1
+      '@textlint/module-interop': 15.8.0
+      '@textlint/resolver': 15.8.0
+      '@textlint/types': 15.8.0
+      debug: 4.4.3
+      js-yaml: 4.3.2
+      lodash: 4.18.1
+      pluralize: 2.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      table: 6.9.0
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@textlint/module-interop@15.8.0': {}
+
+  '@textlint/resolver@15.8.0': {}
+
+  '@textlint/types@15.8.0':
+    dependencies:
+      '@textlint/ast-node-types': 15.8.0
+
+  '@types/node@24.10.1':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@types/normalize-package-data@2.4.4': {}
+
+  '@types/sarif@2.1.7': {}
+
+  '@types/vscode@1.95.0': {}
+
+  '@typespec/ts-http-runtime@0.3.9':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vscode/vsce-sign-alpine-arm64@2.0.6':
+    optional: true
+
+  '@vscode/vsce-sign-alpine-x64@2.0.6':
+    optional: true
+
+  '@vscode/vsce-sign-darwin-arm64@2.0.6':
+    optional: true
+
+  '@vscode/vsce-sign-darwin-x64@2.0.6':
+    optional: true
+
+  '@vscode/vsce-sign-linux-arm64@2.0.6':
+    optional: true
+
+  '@vscode/vsce-sign-linux-arm@2.0.6':
+    optional: true
+
+  '@vscode/vsce-sign-linux-x64@2.0.6':
+    optional: true
+
+  '@vscode/vsce-sign-win32-arm64@2.0.6':
+    optional: true
+
+  '@vscode/vsce-sign-win32-x64@2.0.6':
+    optional: true
+
+  '@vscode/vsce-sign@2.1.0':
+    optionalDependencies:
+      '@vscode/vsce-sign-alpine-arm64': 2.0.6
+      '@vscode/vsce-sign-alpine-x64': 2.0.6
+      '@vscode/vsce-sign-darwin-arm64': 2.0.6
+      '@vscode/vsce-sign-darwin-x64': 2.0.6
+      '@vscode/vsce-sign-linux-arm': 2.0.6
+      '@vscode/vsce-sign-linux-arm64': 2.0.6
+      '@vscode/vsce-sign-linux-x64': 2.0.6
+      '@vscode/vsce-sign-win32-arm64': 2.0.6
+      '@vscode/vsce-sign-win32-x64': 2.0.6
+
+  '@vscode/vsce@3.6.2':
+    dependencies:
+      '@azure/identity': 4.13.2
+      '@secretlint/node': 10.2.2
+      '@secretlint/secretlint-formatter-sarif': 10.2.2
+      '@secretlint/secretlint-rule-no-dotenv': 10.2.2
+      '@secretlint/secretlint-rule-preset-recommend': 10.2.2
+      '@vscode/vsce-sign': 2.1.0
+      azure-devops-node-api: 12.5.0
+      chalk: 4.1.2
+      cheerio: 1.2.0
+      cockatiel: 3.2.1
+      commander: 12.1.0
+      form-data: 4.0.6
+      glob: 11.1.0
+      hosted-git-info: 4.1.0
+      jsonc-parser: 3.3.1
+      leven: 3.1.0
+      markdown-it: 14.3.1
+      mime: 1.6.0
+      minimatch: 3.1.5
+      parse-semver: 1.1.1
+      read: 1.0.7
+      secretlint: 10.2.2
+      semver: 7.8.5
+      tmp: 0.2.7
+      typed-rest-client: 1.8.11
+      url-join: 4.0.1
+      xml2js: 0.5.0
+      yauzl: 2.10.0
+      yazl: 2.5.1
+    optionalDependencies:
+      keytar: 7.9.0
+    transitivePeerDependencies:
+      - supports-color
+
+  agent-base@7.1.4: {}
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.7
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.3.0: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  astral-regex@2.0.0: {}
+
+  asynckit@0.4.0: {}
+
+  azure-devops-node-api@12.5.0:
+    dependencies:
+      tunnel: 0.0.6
+      typed-rest-client: 1.8.11
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  base64-js@1.5.1:
+    optional: true
+
+  binaryextensions@6.11.0:
+    dependencies:
+      editions: 6.22.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+    optional: true
+
+  boolbase@1.0.0: {}
+
+  boundary@2.0.0: {}
+
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  buffer-crc32@0.2.13: {}
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    optional: true
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.29.1
+      whatwg-mimetype: 4.0.0
+
+  chownr@1.1.4:
+    optional: true
+
+  cockatiel@3.2.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  commander@12.1.0: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+    optional: true
+
+  deep-extend@0.6.0:
+    optional: true
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.1:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
+  delayed-stream@1.0.0: {}
+
+  detect-libc@2.1.2:
+    optional: true
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  editions@6.22.0:
+    dependencies:
+      version-range: 4.15.0
+
+  emoji-regex@8.0.0: {}
+
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+    optional: true
+
+  entities@4.5.0: {}
+
+  entities@6.0.1: {}
+
+  entities@7.0.1: {}
+
+  environment@1.1.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  expand-template@2.0.3:
+    optional: true
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-uri@3.1.7: {}
+
+  fastq@1.20.3:
+    dependencies:
+      reusify: 1.1.0
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
+  fs-constants@1.0.0:
+    optional: true
+
+  fs-extra@11.4.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  github-from-package@0.0.0:
+    optional: true
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.6
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+
+  globby@14.1.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 2.3.0
+      fast-glob: 3.3.3
+      ignore: 7.0.9
+      path-type: 6.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.3.0
+
+  gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hosted-git-info@4.1.0:
+    dependencies:
+      lru-cache: 6.0.0
+
+  hosted-git-info@7.0.2:
+    dependencies:
+      lru-cache: 10.4.3
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1:
+    optional: true
+
+  ignore@7.0.9: {}
+
+  index-to-position@1.2.0: {}
+
+  inherits@2.0.4:
+    optional: true
+
+  ini@1.3.8:
+    optional: true
+
+  is-docker@3.0.0: {}
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-number@7.0.0: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  isexe@2.0.0: {}
+
+  istextorbinary@9.5.0:
+    dependencies:
+      binaryextensions: 6.11.0
+      editions: 6.22.0
+      textextensions: 6.11.0
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.3.2:
+    dependencies:
+      argparse: 2.0.1
+
+  json-schema-traverse@1.0.0: {}
+
+  json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.8.5
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
+  keytar@7.9.0:
+    dependencies:
+      node-addon-api: 4.3.0
+      prebuild-install: 7.1.3
+    optional: true
+
+  leven@3.1.0: {}
+
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
+  lodash.once@4.1.1: {}
+
+  lodash.truncate@4.4.2: {}
+
+  lodash@4.18.1: {}
+
+  lru-cache@10.4.3: {}
+
+  lru-cache@11.5.2: {}
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+
+  markdown-it@14.3.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  math-intrinsics@1.1.0: {}
+
+  mdurl@2.1.0: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@1.6.0: {}
+
+  mimic-response@3.1.0:
+    optional: true
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.18
+
+  minimist@1.2.8:
+    optional: true
+
+  minipass@7.1.3: {}
+
+  mkdirp-classic@0.5.3:
+    optional: true
+
+  ms@2.1.3: {}
+
+  mute-stream@0.0.8: {}
+
+  napi-build-utils@2.0.0:
+    optional: true
+
+  node-abi@3.96.0:
+    dependencies:
+      semver: 7.8.5
+    optional: true
+
+  node-addon-api@4.3.0:
+    optional: true
+
+  node-sarif-builder@3.4.0:
+    dependencies:
+      '@types/sarif': 2.1.7
+      fs-extra: 11.4.0
+
+  normalize-package-data@6.0.2:
+    dependencies:
+      hosted-git-info: 7.0.2
+      semver: 7.8.5
+      validate-npm-package-license: 3.0.4
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
+  object-inspect@1.13.4: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+    optional: true
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.1
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
+  p-map@7.0.7: {}
+
+  package-json-from-dist@1.0.1: {}
+
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
+
+  parse-semver@1.1.1:
+    dependencies:
+      semver: 5.7.2
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  path-key@3.1.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
+
+  path-type@6.0.0: {}
+
+  pend@1.2.0: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  pluralize@2.0.0: {}
+
+  pluralize@8.0.0: {}
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.96.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.5
+      tunnel-agent: 0.6.0
+    optional: true
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+    optional: true
+
+  punycode.js@2.3.1: {}
+
+  qs@6.16.0:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  queue-microtask@1.2.3: {}
+
+  rc-config-loader@4.1.4:
+    dependencies:
+      debug: 4.4.3
+      js-yaml: 4.3.2
+      json5: 2.2.3
+      require-from-string: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+    optional: true
+
+  read-pkg@9.0.1:
+    dependencies:
+      '@types/normalize-package-data': 2.4.4
+      normalize-package-data: 6.0.2
+      parse-json: 8.3.0
+      type-fest: 4.41.0
+      unicorn-magic: 0.1.0
+
+  read@1.0.7:
+    dependencies:
+      mute-stream: 0.0.8
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    optional: true
+
+  require-from-string@2.0.2: {}
+
+  reusify@1.1.0: {}
+
+  run-applescript@7.1.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  sax@1.6.1: {}
+
+  secretlint@10.2.2:
+    dependencies:
+      '@secretlint/config-creator': 10.2.2
+      '@secretlint/formatter': 10.2.2
+      '@secretlint/node': 10.2.2
+      '@secretlint/profiler': 10.2.2
+      debug: 4.4.3
+      globby: 14.1.0
+      read-pkg: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  semver@5.7.2: {}
+
+  semver@7.8.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1:
+    optional: true
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+    optional: true
+
+  slash@5.1.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.23
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
+
+  strip-json-comments@2.0.1:
+    optional: true
+
+  structured-source@4.0.0:
+    dependencies:
+      boundary: 2.0.0
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.20.0
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+    optional: true
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+    optional: true
+
+  terminal-link@4.0.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      supports-hyperlinks: 3.2.0
+
+  text-table@0.2.0: {}
+
+  textextensions@6.11.0:
+    dependencies:
+      editions: 6.22.0
+
+  tmp@0.2.7: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  tslib@2.8.1: {}
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
+
+  tunnel@0.0.6: {}
+
+  type-fest@4.41.0: {}
+
+  typed-rest-client@1.8.11:
+    dependencies:
+      qs: 6.16.0
+      tunnel: 0.0.6
+      underscore: 1.13.8
+
+  typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
+
+  underscore@1.13.8: {}
+
+  undici-types@7.16.0: {}
+
+  undici@7.29.1: {}
+
+  unicorn-magic@0.1.0: {}
+
+  unicorn-magic@0.3.0: {}
+
+  universalify@2.0.1: {}
+
+  url-join@4.0.1: {}
+
+  util-deprecate@1.0.2:
+    optional: true
+
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
+
+  version-range@4.15.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wrappy@1.0.2:
+    optional: true
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
+
+  xml2js@0.5.0:
+    dependencies:
+      sax: 1.6.1
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
+
+  yallist@4.0.0: {}
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+
+  yazl@2.5.1:
+    dependencies:
+      buffer-crc32: 0.2.13

--- a/apps/vscode/scripts/build.mjs
+++ b/apps/vscode/scripts/build.mjs
@@ -1,0 +1,15 @@
+import { build } from 'esbuild'
+import { copyFile, mkdir } from 'node:fs/promises'
+
+await build({
+  entryPoints: ['src/extension.ts'],
+  outfile: 'dist/extension.js',
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: 'node20',
+  external: ['vscode'],
+})
+await copyFile('../../LICENSE', 'dist/LICENSE')
+await copyFile('../../THIRD-PARTY-NOTICES.md', 'dist/THIRD-PARTY-NOTICES.md')
+await mkdir('../../artifacts', { recursive: true })

--- a/apps/vscode/src/document-edit.ts
+++ b/apps/vscode/src/document-edit.ts
@@ -1,0 +1,20 @@
+/** Preserve the document's EOL convention and existing final newline. */
+export function normalizeDocumentMarkdown(markdown: string, original: string, eol: string): string {
+  let normalized = markdown.replace(/\r\n?/g, '\n')
+  if (original.endsWith('\n') && !normalized.endsWith('\n')) normalized += '\n'
+  return eol === '\r\n' ? normalized.replace(/\n/g, '\r\n') : normalized
+}
+
+/** A single minimal contiguous replacement, expressed as UTF-16 offsets. */
+export function documentReplacement(before: string, after: string): { start: number; end: number; text: string } | undefined {
+  if (before === after) return undefined
+  let start = 0
+  while (start < before.length && start < after.length && before[start] === after[start]) start++
+  // Do not put VS Code ranges inside a surrogate pair or a CRLF sequence.
+  if (start > 0 && (/[\uD800-\uDBFF]/.test(before[start - 1]!) || before[start - 1] === '\r')) start--
+  let end = before.length
+  let afterEnd = after.length
+  while (end > start && afterEnd > start && before[end - 1] === after[afterEnd - 1]) { end--; afterEnd-- }
+  if (end < before.length && (/[\uDC00-\uDFFF]/.test(before[end]!) || before[end] === '\n')) { end++; afterEnd++ }
+  return { start, end, text: after.slice(start, afterEnd) }
+}

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -1,0 +1,253 @@
+import * as vscode from 'vscode'
+import { documentReplacement, normalizeDocumentMarkdown } from './document-edit'
+import { localResourceRoots, resolveDocumentLink } from './resources'
+import { webviewHtml } from './webview'
+import { isWebviewMessage, type DocumentSnapshot, type ExtensionMessage, type HostAction, type WebviewMessage } from '../../../packages/editor-web/src/vscode-protocol'
+
+const viewType = 'markleaf.editor'
+type EditMessage = Extract<WebviewMessage, { type: 'edit' }>
+
+function activeResource(): vscode.Uri | undefined {
+  const input = vscode.window.tabGroups.activeTabGroup.activeTab?.input
+  if (input instanceof vscode.TabInputText || input instanceof vscode.TabInputCustom) return input.uri
+  return vscode.window.activeTextEditor?.document.uri
+}
+
+const formats = [
+  ['正文', 'setParagraph'], ['一级标题', 'setHeading1'], ['二级标题', 'setHeading2'], ['三级标题', 'setHeading3'],
+  ['四级标题', 'setHeading4'], ['五级标题', 'setHeading5'], ['六级标题', 'setHeading6'],
+  ['无序列表', 'toggleBulletList'], ['有序列表', 'toggleOrderedList'], ['任务列表', 'toggleTaskList'],
+  ['引用', 'toggleBlockquote'], ['代码块', 'toggleCodeBlock'], ['分隔线', 'insertHorizontalRule'],
+  ['插入表格 (3 × 3)', 'insertTable'], ['上方插入行', 'addRowBefore'], ['下方插入行', 'addRowAfter'],
+  ['删除行', 'deleteRow'], ['左侧插入列', 'addColumnBefore'], ['右侧插入列', 'addColumnAfter'],
+  ['删除列', 'deleteColumn'], ['删除表格', 'deleteTable'],
+  ['行内公式', 'insertMathInline'], ['独立公式', 'insertMathBlock'], ['Mermaid 图表', 'insertMermaid'],
+  ['备注提示框', 'insertAlertNote'], ['警告提示框', 'insertAlertWarning'],
+].map(([label, command]) => ({ label: label!, command: command! }))
+
+class EditorPanel implements vscode.Disposable {
+  private readonly subscriptions: vscode.Disposable[] = []
+  private applying?: { target: string; version?: number }
+  private ready = false
+  private disposed = false
+  private flushId = 0
+  private readonly flushes = new Map<number, { resolve(success: boolean): void; timer: ReturnType<typeof setTimeout> }>()
+
+  constructor(readonly document: vscode.TextDocument, readonly panel: vscode.WebviewPanel) {
+    this.subscriptions.push(
+      panel.webview.onDidReceiveMessage((message: unknown) => {
+        if (isWebviewMessage(message)) void this.receive(message).catch(error => this.report(error))
+      }),
+      vscode.workspace.onDidChangeTextDocument(event => {
+        if (event.document !== document || event.contentChanges.length === 0) return
+        if (this.applying?.target === document.getText()) {
+          this.applying.version = document.version
+          return
+        }
+        this.post(this.snapshot())
+      }),
+      vscode.workspace.onWillSaveTextDocument(event => {
+        if (event.document === document && this.ready && !this.disposed) {
+          // VS Code also invokes this path for menu Save and Auto Save.
+          event.waitUntil(this.flush().then(success => {
+            if (!success) throw new Error('MarkLeaf has unsynchronized edits; recover the draft before saving.')
+          }))
+        }
+      }),
+      vscode.workspace.onDidChangeConfiguration(event => {
+        if (event.affectsConfiguration('markleaf', document.uri)) this.settings()
+      }),
+    )
+  }
+
+  dispose(): void {
+    this.disposed = true
+    this.subscriptions.forEach(subscription => subscription.dispose())
+    for (const pending of this.flushes.values()) { clearTimeout(pending.timer); pending.resolve(false) }
+    this.flushes.clear()
+  }
+
+  private snapshot(): DocumentSnapshot {
+    return { type: 'document', version: this.document.version, markdown: this.document.getText(),
+      writable: vscode.workspace.fs.isWritableFileSystem(this.document.uri.scheme) !== false }
+  }
+
+  private post(message: ExtensionMessage): void {
+    if (!this.disposed) void this.panel.webview.postMessage(message)
+  }
+
+  private report(error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error)
+    this.post({ type: 'error', message })
+    void vscode.window.showErrorMessage(`MarkLeaf: ${message}`)
+  }
+
+  private settings(): void {
+    const config = vscode.workspace.getConfiguration('markleaf', this.document.uri)
+    this.post({ type: 'settings', fontSize: config.get('fontSize', 16), maxWidth: config.get('maxWidth', 820), defaultMode: config.get('defaultMode', 'edit') })
+  }
+
+  flush(): Promise<boolean> {
+    if (!this.ready || this.disposed) return Promise.resolve(false)
+    return new Promise(resolve => {
+      const requestId = ++this.flushId
+      const timer = setTimeout(() => { this.flushes.delete(requestId); resolve(false) }, 1200)
+      this.flushes.set(requestId, { resolve, timer })
+      this.post({ type: 'flush', requestId })
+    })
+  }
+
+  async openSource(beside: boolean): Promise<void> {
+    if (!await this.flush()) throw new Error('未同步的内容仍在 MarkLeaf 中，请先完成输入或打开冲突草稿。')
+    await vscode.commands.executeCommand('vscode.openWith', this.document.uri, 'default', {
+      viewColumn: beside ? vscode.ViewColumn.Beside : this.panel.viewColumn,
+    })
+  }
+
+  private async edit(message: EditMessage): Promise<void> {
+    const reject = (error: string): void => this.post({ type: 'rejected', sequence: message.sequence, document: this.snapshot(), error })
+    if (this.applying || message.baseVersion !== this.document.version || this.document.isClosed) {
+      reject('文件版本已改变。未同步的编辑保留在此处，请打开为草稿后与源码合并。')
+      return
+    }
+    const before = this.document.getText()
+    const target = normalizeDocumentMarkdown(message.markdown, before, this.document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n')
+    const replacement = documentReplacement(before, target)
+    if (!replacement) {
+      this.post({ type: 'accepted', sequence: message.sequence, version: this.document.version })
+      return
+    }
+    const edit = new vscode.WorkspaceEdit()
+    edit.replace(this.document.uri, new vscode.Range(this.document.positionAt(replacement.start), this.document.positionAt(replacement.end)), replacement.text)
+    const applying = this.applying = { target, version: undefined as number | undefined }
+    try {
+      const applied = await vscode.workspace.applyEdit(edit)
+      if (!applied || applying.version !== this.document.version || this.document.getText() !== target) {
+        reject('VS Code 未能确认此次编辑，文件可能已发生变化。未同步内容已保留，请打开为草稿。')
+      } else {
+        this.post({ type: 'accepted', sequence: message.sequence, version: this.document.version })
+      }
+    } catch (error) {
+      reject(`写入 VS Code 文档失败：${error instanceof Error ? error.message : String(error)}。未同步内容已保留。`)
+    } finally {
+      this.applying = undefined
+    }
+  }
+
+  private async action(action: HostAction): Promise<void> {
+    switch (action) {
+      case 'save':
+        if (!await this.document.save()) throw new Error('VS Code 未保存此文档。')
+        break
+      case 'undo': case 'redo':
+        if (!this.panel.active) throw new Error('当前编辑器已切换，请聚焦原文档后再执行撤销或重做。')
+        await vscode.commands.executeCommand(action)
+        break
+      case 'openSource': case 'openSourceBeside': await this.openSource(action === 'openSourceBeside'); break
+      case 'format': {
+        const picked = await vscode.window.showQuickPick(formats, { placeHolder: '选择 Markdown 格式或表格操作' })
+        if (picked) this.post({ type: 'command', command: picked.command })
+        break
+      }
+      case 'insertLink': case 'insertImage': {
+        const text = await vscode.window.showInputBox({ prompt: action === 'insertImage' ? '图片地址（相对于 Markdown 文件的路径，或 HTTP/HTTPS URL）' : '链接地址', ignoreFocusOut: true })
+        if (text) {
+          if (!resolveDocumentLink(this.document, text)) throw new Error('请输入本地路径或 HTTP/HTTPS 链接。')
+          this.post({ type: 'command', command: action === 'insertImage' ? 'insertImage' : 'setLink', text })
+        }
+        break
+      }
+    }
+  }
+
+  private async receive(message: WebviewMessage): Promise<void> {
+    switch (message.type) {
+      case 'ready': this.ready = true; this.settings(); this.post(this.snapshot()); break
+      case 'edit': await this.edit(message); break
+      case 'action':
+        try { await this.action(message.action) }
+        finally { this.post({ type: 'actionFinished' }) }
+        break
+      case 'flushed': {
+        const pending = this.flushes.get(message.requestId)
+        if (pending) { clearTimeout(pending.timer); this.flushes.delete(message.requestId); pending.resolve(message.success) }
+        break
+      }
+      case 'resolveImages': {
+        const urls: Record<string, string> = Object.create(null)
+        for (const path of message.paths) {
+          const uri = resolveDocumentLink(this.document, path)
+          if (uri && !['http', 'https', 'mailto'].includes(uri.scheme)) urls[path] = this.panel.webview.asWebviewUri(uri).toString()
+        }
+        this.post({ type: 'images', urls })
+        break
+      }
+      case 'recoverDraft': {
+        // An untitled VS Code document makes the unsaved content visible and recoverable.
+        const draft = await vscode.workspace.openTextDocument({ language: 'markdown', content: message.markdown })
+        await vscode.window.showTextDocument(draft, { viewColumn: vscode.ViewColumn.Beside, preview: false })
+        this.post({ type: 'recovered', document: this.snapshot() })
+        break
+      }
+      case 'copy': await vscode.env.clipboard.writeText(message.text); break
+      case 'codeLanguage': {
+        const language = await vscode.window.showInputBox({ prompt: '代码块语言（例如 typescript、python、mermaid）', value: message.language })
+        if (language !== undefined) this.post({ type: 'command', command: 'setCodeBlockLanguageAt', text: JSON.stringify({ position: message.position, language }) })
+        break
+      }
+      case 'openLink': {
+        const uri = resolveDocumentLink(this.document, message.href)
+        if (!uri) throw new Error('不支持此链接地址。')
+        if (['http', 'https', 'mailto'].includes(uri.scheme)) await vscode.env.openExternal(uri)
+        else await vscode.commands.executeCommand('vscode.open', uri)
+        break
+      }
+      case 'error': this.report(message.message); break
+    }
+  }
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+  const panels = new Set<EditorPanel>()
+  const active = (uri?: vscode.Uri): EditorPanel | undefined => [...panels].find(item => uri
+    ? item.document.uri.toString() === uri.toString() : item.panel.active)
+  const provider: vscode.CustomTextEditorProvider = {
+    async resolveCustomTextEditor(document, panel) {
+      const assets = vscode.Uri.joinPath(context.extensionUri, 'dist', 'webview')
+      panel.webview.options = { enableScripts: true, localResourceRoots: localResourceRoots(document, assets) }
+      const editor = new EditorPanel(document, panel)
+      panels.add(editor)
+      panel.onDidDispose(() => { panels.delete(editor); editor.dispose() }, undefined, context.subscriptions)
+      try { panel.webview.html = await webviewHtml(panel.webview, assets) }
+      catch (error) { panels.delete(editor); editor.dispose(); throw error }
+    },
+  }
+  context.subscriptions.push(
+    vscode.window.registerCustomEditorProvider(viewType, provider, {
+      webviewOptions: { retainContextWhenHidden: true, enableFindWidget: true },
+      supportsMultipleEditorsPerDocument: false,
+    }),
+    vscode.commands.registerCommand('markleaf.open', async (uri?: vscode.Uri) => {
+      const resource = uri ?? activeResource()
+      if (!resource) { void vscode.window.showInformationMessage('请先打开或选择一个 Markdown 文件。'); return }
+      await vscode.commands.executeCommand('vscode.openWith', resource, viewType)
+    }),
+    vscode.commands.registerCommand('markleaf.toggleEditor', async () => {
+      try {
+        const visual = active()
+        if (visual) await visual.openSource(false)
+        else {
+          const document = vscode.window.activeTextEditor?.document
+          if (document?.languageId === 'markdown') await vscode.commands.executeCommand('vscode.openWith', document.uri, viewType)
+        }
+      } catch (error) {
+        void vscode.window.showErrorMessage(`MarkLeaf: ${error instanceof Error ? error.message : String(error)}`)
+      }
+    }),
+    ...(['openSource', 'openSourceBeside'] as const).map(command => vscode.commands.registerCommand(`markleaf.${command}`, async (uri?: vscode.Uri) => {
+      try { await active(uri)?.openSource(command === 'openSourceBeside') }
+      catch (error) { void vscode.window.showErrorMessage(`MarkLeaf: ${error instanceof Error ? error.message : String(error)}`) }
+    })),
+    { dispose: () => panels.forEach(panel => panel.dispose()) },
+  )
+}

--- a/apps/vscode/src/resources.ts
+++ b/apps/vscode/src/resources.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode'
+
+export function documentDirectory(document: vscode.TextDocument): vscode.Uri | undefined {
+  if (document.isUntitled) return vscode.workspace.workspaceFolders?.[0]?.uri
+  return vscode.Uri.joinPath(document.uri, '..')
+}
+
+/** Resolve against the document URI, so remote documents retain their authority. */
+export function resolveDocumentLink(document: vscode.TextDocument, value: string): vscode.Uri | undefined {
+  const href = value.trim()
+  if (!href) return undefined
+  if (/^https?:\/\//i.test(href) || /^mailto:/i.test(href)) return vscode.Uri.parse(href)
+  if (/^file:/i.test(href)) return vscode.Uri.parse(href)
+  if (/^[a-z]:[\\/]/i.test(href)) return vscode.Uri.file(href)
+  if (/^[a-z][a-z\d+.-]*:/i.test(href) || href.startsWith('//')) return undefined
+  const base = documentDirectory(document)
+  if (!base) return undefined
+  const match = /^([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/.exec(href)
+  if (!match) return undefined
+  let pathPart = match[1] ?? ''
+  try { pathPart = decodeURIComponent(pathPart) } catch { /* Literal invalid percent escapes. */ }
+  pathPart = pathPart.replace(/\\/g, '/')
+  const uri = pathPart.startsWith('/') ? base.with({ path: pathPart }) : vscode.Uri.joinPath(base, pathPart)
+  return uri.with({ query: match[2] ?? '', fragment: match[3] ?? '' })
+}
+
+export function localResourceRoots(document: vscode.TextDocument, assets: vscode.Uri): vscode.Uri[] {
+  const directory = documentDirectory(document)
+  return [assets, ...(vscode.workspace.workspaceFolders ?? []).map(folder => folder.uri), ...(directory ? [directory] : [])]
+}

--- a/apps/vscode/src/webview.ts
+++ b/apps/vscode/src/webview.ts
@@ -1,0 +1,48 @@
+import * as vscode from 'vscode'
+import { randomBytes } from 'node:crypto'
+
+function escapeAttribute(value: string): string {
+  return value.replace(/[&<>"']/g, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[char]!)
+}
+
+export async function webviewHtml(webview: vscode.Webview, assets: vscode.Uri): Promise<string> {
+  const bytes = await vscode.workspace.fs.readFile(vscode.Uri.joinPath(assets, '.vite', 'manifest.json'))
+  const manifest = JSON.parse(Buffer.from(bytes).toString('utf8')) as Record<string, { file: string; css?: string[] }>
+  const entry = manifest['src/vscode.ts']
+  if (!entry) throw new Error('MarkLeaf webview build is missing. Run pnpm build:vscode.')
+  const assetUrl = (file: string): string => escapeAttribute(webview.asWebviewUri(vscode.Uri.joinPath(assets, file)).toString())
+  const nonce = randomBytes(18).toString('base64')
+  const csp = `default-src 'none'; script-src 'nonce-${nonce}' ${webview.cspSource}; style-src ${webview.cspSource} 'unsafe-inline'; img-src ${webview.cspSource} https: http: data:; font-src ${webview.cspSource} data:; connect-src ${webview.cspSource}; base-uri 'none'; form-action 'none';`
+  return `<!doctype html>
+<html lang="zh-CN"><head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="${escapeAttribute(csp)}">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+${(entry.css ?? []).map(css => `<link rel="stylesheet" href="${assetUrl(css)}">`).join('\n')}
+<title>MarkLeaf</title>
+</head><body>
+<div id="app">
+  <header id="toolbar" aria-label="Markdown 工具栏">
+    <strong class="brand">MarkLeaf</strong>
+    <button id="mode" type="button" title="切换阅读与编辑模式">阅读</button>
+    <span class="divider"></span>
+    <button data-command="toggleBold" data-edit type="button" title="粗体 (Ctrl/Cmd+B)"><b>B</b></button>
+    <button data-command="toggleItalic" data-edit type="button" title="斜体 (Ctrl/Cmd+I)"><i>I</i></button>
+    <button data-command="toggleStrike" data-edit type="button" title="删除线"><s>S</s></button>
+    <button data-command="toggleCode" data-edit type="button" title="行内代码">&lt;/&gt;</button>
+    <button data-action="format" data-edit type="button">格式…</button>
+    <button data-action="insertLink" data-edit type="button">链接</button>
+    <button data-action="insertImage" data-edit type="button">图片</button>
+    <span class="spacer"></span>
+    <button data-action="undo" data-edit type="button" title="撤销">↶</button>
+    <button data-action="redo" data-edit type="button" title="重做">↷</button>
+    <button data-action="openSource" type="button" title="切换源码 / 渲染视图 (Ctrl/Cmd+Shift+V)">源码</button>
+    <button data-action="openSourceBeside" type="button" title="在侧边打开 VS Code 源码编辑器">并排</button>
+  </header>
+  <div id="notice" role="status" hidden><span id="notice-text"></span><button id="recover" type="button" hidden>将未同步内容打开为草稿</button></div>
+  <main id="editor" class="markleaf-style-sans" aria-label="Markdown 文档" aria-busy="true"></main>
+  <footer><span id="sync-status" role="status">正在加载…</span><span id="word-count"></span></footer>
+</div>
+<script nonce="${nonce}" type="module" src="${assetUrl(entry.file)}"></script>
+</body></html>`
+}

--- a/apps/vscode/tsconfig.json
+++ b/apps/vscode/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node", "vscode"],
+    "lib": ["ES2022"]
+  },
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "packageManager": "pnpm@11.9.0",
   "scripts": {
     "build:editor-web": "pnpm --dir packages/editor-web build",
-    "test:editor-web": "pnpm --dir packages/editor-web test"
+    "test:editor-web": "pnpm --dir packages/editor-web test",
+    "build:vscode": "pnpm --dir packages/editor-web build:vscode && pnpm --dir apps/vscode build",
+    "package:vscode": "pnpm build:vscode && pnpm --dir apps/vscode package"
   }
 }

--- a/packages/editor-web/package.json
+++ b/packages/editor-web/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",
+    "build:vscode": "tsc --noEmit && vite build --mode vscode",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/editor-web/pnpm-workspace.yaml
+++ b/packages/editor-web/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages:
+  - '.'
 allowBuilds:
   esbuild: true
 onlyBuiltDependencies:

--- a/packages/editor-web/src/editor.ts
+++ b/packages/editor-web/src/editor.ts
@@ -3354,6 +3354,8 @@ export const editorExtensions = [
 export type EditorCreationOptions = {
   themedVisualSelection?: boolean
   handlePaste?: (event: ClipboardEvent) => boolean
+  // Text-document hosts own undo/redo; native hosts retain Tiptap history.
+  externalHistory?: boolean
 }
 
 export function createEditor(
@@ -3362,11 +3364,16 @@ export function createEditor(
   readOnly = false,
   options: EditorCreationOptions = {},
 ): Editor {
+  const extensions = options.externalHistory
+    ? editorExtensions.map(extension => extension.name === 'starterKit'
+      ? extension.configure({ undoRedo: false })
+      : extension)
+    : editorExtensions
   const editor = new Editor({
     element,
     extensions: options.themedVisualSelection
-      ? [...editorExtensions, ThemedSelection]
-      : editorExtensions,
+      ? [...extensions, ThemedSelection]
+      : extensions,
     content: protectFootnoteDefinitionsForVisualMarkdown(normalizeDisplayMathAfterList(content)),
     contentType: 'markdown',
     autofocus: false,
@@ -3376,13 +3383,14 @@ export function createEditor(
         class: 'markleaf-document',
         spellcheck: 'true',
       },
-      handleDOMEvents: readOnly ? {
+      handleDOMEvents: {
         dragstart: (_view, event) => {
+          if (editor.isEditable) return false
           event.dataTransfer?.clearData()
           event.preventDefault()
           return true
         },
-      } : undefined,
+      },
       // ProseMirror owns the editor's paste event pipeline. Handling custom
       // clipboard formats here guarantees that the callback runs before its
       // default HTML/text insertion and survives editor recreation.
@@ -3419,6 +3427,26 @@ export function replaceEditorDocument(
 ): Editor {
   editor.destroy()
   return createEditor(element, content, readOnly, options)
+}
+
+/** Apply a text host's external update without replacing the editor or its DOM.
+ * The host must suppress its change callback while calling this function. */
+export function updateEditorMarkdown(editor: Editor, content: string): void {
+  const selection = editor.state.selection
+  editor.commands.setContent(
+    protectFootnoteDefinitionsForVisualMarkdown(normalizeDisplayMathAfterList(content)),
+    { contentType: 'markdown', emitUpdate: false },
+  )
+  normalizeTableCaptions(editor)
+  originalListMarkdown.delete(editor)
+  if (hasListFormattingThatNeedsPreservation(content)) {
+    originalListMarkdown.set(editor, { doc: editor.state.doc, markdown: content })
+  }
+  const size = editor.state.doc.content.size
+  editor.view.dispatch(editor.state.tr.setSelection(TextSelection.between(
+    editor.state.doc.resolve(Math.min(selection.from, size)),
+    editor.state.doc.resolve(Math.min(selection.to, size)),
+  )).setMeta('addToHistory', false))
 }
 
 /** Parse clipboard plain text through the same complete Markdown pipeline used
@@ -3572,7 +3600,14 @@ export function setCodeHighlightVisible(editor: Editor, visible: boolean): void 
   editor.view.dispatch(editor.state.tr)
 }
 
+let hostImageResolver: ((markdownPath: string) => string) | undefined
+
+export function setHostImageResolver(resolver?: (markdownPath: string) => string): void {
+  hostImageResolver = resolver
+}
+
 export function toVirtualImageUrl(markdownPath: string): string {
+  if (hostImageResolver) return hostImageResolver(markdownPath)
   // 远程图片（http/https）原样返回，由浏览器直接加载；仅本地路径走虚拟资源服务。
   if (/^(https?:|mailto:)/i.test(markdownPath)) {
     return markdownPath

--- a/packages/editor-web/src/vscode-protocol.ts
+++ b/packages/editor-web/src/vscode-protocol.ts
@@ -1,0 +1,52 @@
+// VS Code-specific document transport. Native hosts keep protocol.ts unchanged.
+export type DocumentSnapshot = {
+  type: 'document'
+  version: number
+  markdown: string
+  writable: boolean
+}
+
+export type HostAction = 'save' | 'undo' | 'redo' | 'openSource' | 'openSourceBeside'
+  | 'format' | 'insertLink' | 'insertImage'
+
+export type WebviewMessage =
+  | { type: 'ready' }
+  | { type: 'edit'; sequence: number; baseVersion: number; markdown: string }
+  | { type: 'action'; action: HostAction }
+  | { type: 'resolveImages'; paths: string[] }
+  | { type: 'flushed'; requestId: number; success: boolean }
+  | { type: 'recoverDraft'; markdown: string }
+  | { type: 'copy'; text: string }
+  | { type: 'codeLanguage'; position: number; language: string }
+  | { type: 'openLink'; href: string }
+  | { type: 'error'; message: string }
+
+export type ExtensionMessage = DocumentSnapshot
+  | { type: 'recovered'; document: DocumentSnapshot }
+  | { type: 'actionFinished' }
+  | { type: 'accepted'; sequence: number; version: number }
+  | { type: 'rejected'; sequence: number; document: DocumentSnapshot; error: string }
+  | { type: 'flush'; requestId: number }
+  | { type: 'images'; urls: Record<string, string> }
+  | { type: 'command'; command: string; text?: string }
+  | { type: 'settings'; fontSize: number; maxWidth: number; defaultMode: 'read' | 'edit' }
+  | { type: 'error'; message: string }
+
+export function isWebviewMessage(value: unknown): value is WebviewMessage {
+  if (!value || typeof value !== 'object') return false
+  const message = value as Record<string, unknown>
+  const integer = (n: unknown): n is number => Number.isSafeInteger(n) && Number(n) >= 0
+  switch (message.type) {
+    case 'ready': return true
+    case 'edit': return integer(message.sequence) && integer(message.baseVersion) && typeof message.markdown === 'string'
+    case 'action': return ['save', 'undo', 'redo', 'openSource', 'openSourceBeside', 'format', 'insertLink', 'insertImage'].includes(String(message.action))
+    case 'resolveImages': return Array.isArray(message.paths) && message.paths.every(p => typeof p === 'string')
+    case 'flushed': return integer(message.requestId) && typeof message.success === 'boolean'
+    case 'recoverDraft': return typeof message.markdown === 'string'
+    case 'copy': return typeof message.text === 'string'
+    case 'codeLanguage': return integer(message.position) && typeof message.language === 'string'
+    case 'openLink': return typeof message.href === 'string'
+    case 'error': return typeof message.message === 'string'
+    default: return false
+  }
+}

--- a/packages/editor-web/src/vscode-sync.ts
+++ b/packages/editor-web/src/vscode-sync.ts
@@ -1,0 +1,114 @@
+import type { DocumentSnapshot, WebviewMessage } from './vscode-protocol'
+
+type EditMessage = Extract<WebviewMessage, { type: 'edit' }>
+
+/** One edit in flight, with the latest local snapshot queued behind it.
+ * Acknowledgements never parse or replace the visible editor document. */
+export class TextDocumentSync {
+  private version = -1
+  private sequence = 0
+  private acknowledged = ''
+  private visible = ''
+  private inFlight?: EditMessage
+  private composing = false
+  private deferredDocument?: DocumentSnapshot
+  private flushRequests = new Set<number>()
+  conflict: string | undefined
+
+  constructor(private readonly callbacks: {
+    post(message: WebviewMessage): void
+    // Return the initial serialization to distinguish parsing from user edits.
+    render(document: DocumentSnapshot): string
+    status(): void
+  }) {}
+
+  get pending(): boolean {
+    return this.inFlight !== undefined || this.visible !== this.acknowledged || this.composing
+  }
+
+  get markdown(): string { return this.visible }
+
+  receiveDocument(document: DocumentSnapshot): void {
+    if (document.version < this.version) return
+    if (this.composing) {
+      this.deferredDocument = document
+      return
+    }
+    if (this.pending || this.conflict) {
+      this.conflict = '文件已在其他视图中修改。未同步的编辑保留在此处，请先将它打开为草稿，再合并到源码。'
+      this.callbacks.status()
+      this.completeFlushes()
+      return
+    }
+    this.reset(document)
+  }
+
+  reset(document: DocumentSnapshot): void {
+    // Do not associate the old view with a new host version if parsing fails.
+    const rendered = this.callbacks.render(document)
+    this.inFlight = undefined
+    this.deferredDocument = undefined
+    this.conflict = undefined
+    this.version = document.version
+    this.visible = this.acknowledged = rendered
+    this.callbacks.status()
+    this.completeFlushes()
+  }
+
+  change(markdown: string): void {
+    this.visible = markdown
+    this.sendNext()
+  }
+
+  setComposing(composing: boolean): void {
+    this.composing = composing
+    if (!composing && this.deferredDocument) {
+      const document = this.deferredDocument
+      this.deferredDocument = undefined
+      this.receiveDocument(document)
+    }
+    this.sendNext()
+  }
+
+  accept(sequence: number, version: number): void {
+    if (this.inFlight?.sequence !== sequence) return
+    this.version = Math.max(this.version, version)
+    this.acknowledged = this.inFlight.markdown
+    this.inFlight = undefined
+    this.sendNext()
+  }
+
+  reject(sequence: number, error: string): void {
+    if (this.inFlight?.sequence !== sequence) return
+    this.inFlight = undefined
+    this.conflict = error
+    this.callbacks.status()
+    this.completeFlushes()
+  }
+
+  flush(requestId: number): void {
+    this.flushRequests.add(requestId)
+    this.sendNext()
+  }
+
+  private sendNext(): void {
+    if (this.version >= 0 && !this.composing && !this.conflict && !this.inFlight
+      && this.visible !== this.acknowledged) {
+      this.inFlight = {
+        type: 'edit', sequence: ++this.sequence,
+        baseVersion: this.version, markdown: this.visible,
+      }
+      this.callbacks.post(this.inFlight)
+    }
+    this.callbacks.status()
+    this.completeFlushes()
+  }
+
+  private completeFlushes(): void {
+    if (this.pending && !this.conflict) return
+    for (const requestId of this.flushRequests) {
+      this.callbacks.post({ type: 'flushed', requestId, success: !this.conflict })
+    }
+    this.flushRequests.clear()
+  }
+}

--- a/packages/editor-web/src/vscode.css
+++ b/packages/editor-web/src/vscode.css
@@ -1,0 +1,52 @@
+:root {
+  font-family: var(--vscode-font-family, sans-serif);
+  --bg-primary: var(--vscode-editor-background);
+  --bg-secondary: var(--vscode-textCodeBlock-background, var(--vscode-editor-background));
+  --bg-hover: var(--vscode-toolbar-hoverBackground);
+  --bg-selected: var(--vscode-panel-border, #8884);
+  --bg-selected-hover: var(--vscode-widget-border, #8886);
+  --text-primary: var(--vscode-editor-foreground);
+  --text-secondary: var(--vscode-foreground);
+  --text-tertiary: var(--vscode-descriptionForeground);
+  --text-selected: var(--vscode-editor-selectionForeground, var(--vscode-editor-foreground));
+  --text-tertiary-selected: var(--text-selected);
+  --theme-light: var(--vscode-editor-selectionBackground);
+  --theme-dark: var(--vscode-textLink-foreground);
+  --highlight: var(--vscode-editor-findMatchHighlightBackground);
+  --highlight-current: var(--vscode-editor-findMatchBackground);
+  --icon: var(--text-primary);
+  --icon-secondary: var(--text-tertiary);
+  --scrollbar-idle: var(--vscode-scrollbarSlider-background);
+  --scrollbar-active: var(--vscode-scrollbarSlider-activeBackground);
+}
+html { scroll-padding-top: 74px; }
+body { padding: 0; color: var(--text-primary); background: var(--bg-primary); }
+#toolbar {
+  position: sticky; top: 0; z-index: 100;
+  display: flex; flex-wrap: wrap; align-items: center; gap: 4px;
+  padding: 8px 12px; background: var(--bg-primary);
+  border-bottom: 1px solid var(--bg-selected);
+  font-size: 12px;
+}
+.brand { padding: 0 8px 0 2px; font-size: 13px; letter-spacing: .2px; }
+button {
+  font: inherit; color: var(--text-primary); background: transparent;
+  border: 1px solid transparent; border-radius: 4px; padding: 4px 7px;
+  min-height: 28px; cursor: pointer;
+}
+button:hover, button[aria-pressed="true"] { background: var(--bg-hover); }
+button:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 1px; }
+button:disabled { opacity: .4; cursor: default; }
+.divider { width: 1px; height: 20px; background: var(--bg-selected); margin: 0 4px; }
+.spacer { flex: 1; }
+#editor { padding: 28px clamp(16px, 4vw, 48px) 80px; }
+#editor .ProseMirror { min-height: calc(100vh - 180px); }
+#editor .ProseMirror:focus-within { caret-color: var(--vscode-editorCursor-foreground, var(--text-primary)); }
+#editor[data-read-only="true"] { cursor: auto; }
+#editor[data-read-only="true"] .markleaf-image-resize-handle { display: none; }
+#editor .markleaf-document pre { font-family: var(--vscode-editor-font-family, monospace); }
+#notice { position: sticky; top: 45px; z-index: 90; padding: 10px 18px; background: var(--vscode-inputValidation-warningBackground, var(--bg-secondary)); border-bottom: 1px solid var(--vscode-inputValidation-warningBorder, var(--bg-selected)); font-size: 13px; }
+#notice button { margin-left: 8px; color: var(--vscode-textLink-foreground); text-decoration: underline; }
+footer { position: fixed; bottom: 0; left: 0; right: 0; z-index: 100; display: flex; justify-content: space-between; padding: 5px 16px; color: var(--text-tertiary); background: var(--bg-primary); border-top: 1px solid var(--bg-selected); font-size: 11px; }
+[hidden] { display: none !important; }
+@media (max-width: 520px) { .brand, .divider { display: none; } #toolbar { gap: 1px; padding: 6px; } }

--- a/packages/editor-web/src/vscode.ts
+++ b/packages/editor-web/src/vscode.ts
@@ -1,0 +1,299 @@
+import './styles.css'
+import '../../styles/base.css'
+import '../../styles/sans.css'
+import './vscode.css'
+import {
+  collapseSourceEditor, createEditor, executeEditorCommand, expandSourceEditor,
+  getMarkdown, pasteMarkdownText, scrollToFootnoteDefinition, setCodeBlockControlHandlers,
+  setCodeHighlightVisible, setHostImageResolver, shouldParsePastedTextAsMarkdown, updateEditorMarkdown,
+} from './editor'
+import { rerenderMermaidElements } from './mermaid'
+import { TextDocumentSync } from './vscode-sync'
+import type { ExtensionMessage, HostAction, WebviewMessage } from './vscode-protocol'
+
+declare function acquireVsCodeApi(): {
+  postMessage(message: WebviewMessage): void
+  getState(): { mode?: 'read' | 'edit'; scrollTop?: number } | undefined
+  setState(state: { mode: 'read' | 'edit'; scrollTop: number }): void
+}
+
+const vscode = acquireVsCodeApi()
+const post = (message: WebviewMessage): void => vscode.postMessage(message)
+const mount = document.querySelector<HTMLElement>('#editor')!
+const modeButton = document.querySelector<HTMLButtonElement>('#mode')!
+const status = document.querySelector<HTMLElement>('#sync-status')!
+const count = document.querySelector<HTMLElement>('#word-count')!
+const notice = document.querySelector<HTMLElement>('#notice')!
+const noticeText = document.querySelector<HTMLElement>('#notice-text')!
+const recover = document.querySelector<HTMLButtonElement>('#recover')!
+const initialState = vscode.getState()
+let mode = initialState?.mode ?? 'edit'
+let writable = false
+let suppressUpdate = false
+let editor: ReturnType<typeof createEditor> | undefined
+const pendingActions: HostAction[] = []
+let actionInFlight = false
+let noticeError = ''
+let renderingFailed = false
+let restoringScroll = true
+const imageUrls = new Map<string, string>()
+const requestedImages = new Set<string>()
+
+function imageUrl(path: string): string {
+  if (/^https?:\/\//i.test(path)) return path
+  const cached = imageUrls.get(path)
+  if (cached) return cached
+  if (path && !requestedImages.has(path)) {
+    requestedImages.add(path)
+    post({ type: 'resolveImages', paths: [path] })
+  }
+  return ''
+}
+setHostImageResolver(imageUrl)
+setCodeBlockControlHandlers({
+  copyCode: text => post({ type: 'copy', text }),
+  editLanguage: (position, language) => { if (editor?.isEditable) post({ type: 'codeLanguage', position, language }) },
+})
+
+const sync = new TextDocumentSync({
+  post,
+  render(document) {
+    const scrollTop = window.scrollY
+    writable = document.writable
+    suppressUpdate = true
+    try {
+      if (editor) {
+        collapseSourceEditor(editor)
+        updateEditorMarkdown(editor, document.markdown)
+      } else {
+        editor = createEditor(mount, document.markdown, true, {
+          externalHistory: true,
+          handlePaste(event) {
+            if (!editor?.isEditable) return false
+            const text = event.clipboardData?.getData('text/plain') ?? ''
+            const html = event.clipboardData?.getData('text/html') ?? ''
+            if (!editor.isActive('codeBlock') && shouldParsePastedTextAsMarkdown(editor, text, html)) {
+              return pasteMarkdownText(editor, text)
+            }
+            return false
+          },
+        })
+        setCodeHighlightVisible(editor, true)
+        editor.on('update', ({ transaction }) => {
+          if (!suppressUpdate && transaction.docChanged) sync.change(getMarkdown(editor!))
+        })
+        editor.on('selectionUpdate', updateToolbar)
+      }
+      mount.setAttribute('aria-busy', 'false')
+      renderingFailed = false
+      noticeError = ''
+      const target = restoringScroll ? initialState?.scrollTop ?? 0 : scrollTop
+      restoringScroll = false
+      requestAnimationFrame(() => window.scrollTo(0, target))
+      return getMarkdown(editor)
+    } finally { suppressUpdate = false }
+  },
+  status() {
+    if (!editor) return
+    const editable = writable && mode === 'edit' && !sync.conflict && !renderingFailed
+    if (editor.isEditable !== editable) editor.setEditable(editable, false)
+    mount.dataset.readOnly = String(!editable)
+    modeButton.textContent = mode === 'read' ? '编辑' : '阅读'
+    modeButton.setAttribute('aria-pressed', String(mode === 'read'))
+    modeButton.disabled = !writable || !!sync.conflict || renderingFailed
+    for (const button of document.querySelectorAll<HTMLButtonElement>('[data-edit]')) button.disabled = !editable
+    noticeText.textContent = sync.conflict ?? noticeError
+    notice.hidden = !noticeText.textContent
+    recover.hidden = !sync.conflict
+    status.textContent = renderingFailed ? '文档加载失败' : sync.conflict ? '存在未同步编辑' : sync.pending ? '正在同步…' : !writable ? '文件只读' : mode === 'read' ? '阅读模式' : '已同步到 VS Code'
+    count.textContent = `${editor.state.doc.textContent.length.toLocaleString()} 字符`
+    updateToolbar()
+    runNextAction()
+  },
+})
+
+function updateToolbar(): void {
+  if (!editor) return
+  for (const [command, mark] of [['toggleBold', 'bold'], ['toggleItalic', 'italic'], ['toggleStrike', 'strike'], ['toggleCode', 'code']]) {
+    document.querySelector(`[data-command="${command}"]`)?.setAttribute('aria-pressed', String(editor.isActive(mark!)))
+  }
+}
+
+function action(action: HostAction): void {
+  if (sync.conflict) return
+  pendingActions.push(action)
+  runNextAction()
+}
+
+function runNextAction(): void {
+  if (sync.pending || sync.conflict || actionInFlight) return
+  const action = pendingActions.shift()
+  if (action) {
+    actionInFlight = true
+    post({ type: 'action', action })
+  }
+}
+
+function command(command: string, text?: string): void {
+  if (!editor?.isEditable || sync.conflict) return
+  if (!executeEditorCommand(editor, command, text)) {
+    noticeError = '此操作不适用于当前选区。请将光标放入目标段落或表格后重试。'
+    noticeText.textContent = noticeError
+    notice.hidden = false
+  } else {
+    noticeError = ''
+    notice.hidden = true
+  }
+}
+
+document.querySelector('#toolbar')!.addEventListener('mousedown', event => {
+  if ((event.target as Element).closest('button')) event.preventDefault()
+})
+document.querySelector('#toolbar')!.addEventListener('click', event => {
+  const button = (event.target as Element).closest<HTMLButtonElement>('button')
+  if (!button || button.disabled) return
+  if (button.dataset.command) command(button.dataset.command)
+  if (button.dataset.action) action(button.dataset.action as HostAction)
+})
+modeButton.addEventListener('click', () => {
+  if (!editor || sync.pending || sync.conflict) return
+  collapseSourceEditor(editor)
+  mode = mode === 'read' ? 'edit' : 'read'
+  vscode.setState({ mode, scrollTop: window.scrollY })
+  sync.change(getMarkdown(editor))
+})
+recover.addEventListener('click', () => {
+  recover.disabled = true
+  post({ type: 'recoverDraft', markdown: sync.markdown })
+})
+
+// Capture before Tiptap and the formula/Mermaid source controls can use their
+// local history. Composition is submitted as one committed edit.
+window.addEventListener('keydown', event => {
+  const primary = /Mac/i.test(navigator.platform) ? event.metaKey : event.ctrlKey
+  if (!primary || event.altKey || event.isComposing) return
+  const key = event.key.toLowerCase()
+  const requested = key === 's' && !event.shiftKey ? 'save'
+    : key === 'z' ? (event.shiftKey ? 'redo' : 'undo') : key === 'y' ? 'redo' : undefined
+  if (!requested) return
+  event.preventDefault()
+  event.stopImmediatePropagation()
+  action(requested)
+}, true)
+function editorInputTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && (mount.contains(target) || !!target.closest('.markleaf-expanded-source'))
+}
+document.addEventListener('compositionstart', event => {
+  if (editorInputTarget(event.target)) sync.setComposing(true)
+}, true)
+document.addEventListener('compositionend', event => {
+  if (!editorInputTarget(event.target)) return
+  // Let ProseMirror and expanded formula source inputs commit their final DOM.
+  setTimeout(() => {
+    if (editor && !suppressUpdate) sync.change(getMarkdown(editor))
+    sync.setComposing(false)
+  }, 0)
+}, true)
+mount.addEventListener('beforeinput', event => {
+  if (!editor?.isEditable) event.preventDefault()
+}, true)
+mount.addEventListener('click', event => {
+  const target = (event.target as Element)
+  const footnote = target.closest<HTMLElement>('sup[data-footnote-ref]')
+  if (footnote && editor) { event.preventDefault(); scrollToFootnoteDefinition(editor, footnote.dataset.footnoteRef ?? ''); return }
+  const link = target.closest<HTMLAnchorElement>('a[href]')
+  if (!link) return
+  event.preventDefault()
+  const primary = /Mac/i.test(navigator.platform) ? event.metaKey : event.ctrlKey
+  if (mode !== 'read' && !primary) return
+  const href = link.getAttribute('href') ?? ''
+  if (href.startsWith('#')) {
+    let slug = href.slice(1)
+    try { slug = decodeURIComponent(slug) } catch { /* Match the literal fragment. */ }
+    const headings = Array.from(mount.querySelectorAll<HTMLElement>('h1,h2,h3,h4,h5,h6'))
+    const occurrences = new Map<string, number>()
+    const heading = headings.find(element => {
+      const base = (element.textContent ?? '').toLowerCase().replace(/[^\p{L}\p{N}_\-\s]/gu, '').replace(/\s/g, '-')
+      const index = occurrences.get(base) ?? 0
+      occurrences.set(base, index + 1)
+      return slug === (index === 0 ? base : `${base}-${index}`)
+    })
+    heading?.scrollIntoView({ block: 'start', behavior: 'smooth' })
+  } else post({ type: 'openLink', href })
+})
+mount.addEventListener('dblclick', event => {
+  if (!editor || !(event.target instanceof Element)) return
+  const node = event.target.closest('.markleaf-math, .markleaf-mermaid')
+  if (!node) return
+  const kind = node.classList.contains('markleaf-mermaid') ? 'mermaid'
+    : node.classList.contains('markleaf-math-inline') ? 'mathInline' : 'mathBlock'
+  editor.state.doc.descendants((documentNode, position) => {
+    if (documentNode.type.name === kind && editor!.view.nodeDOM(position) === node) {
+      expandSourceEditor(editor!, position, kind)
+      return false
+    }
+    return true
+  })
+})
+
+let scrollFrame = 0
+window.addEventListener('scroll', () => {
+  if (scrollFrame) return
+  scrollFrame = requestAnimationFrame(() => {
+    scrollFrame = 0
+    vscode.setState({ mode, scrollTop: window.scrollY })
+  })
+}, { passive: true })
+const themeObserver = new MutationObserver(() => rerenderMermaidElements(mount))
+themeObserver.observe(document.body, { attributes: true, attributeFilter: ['class', 'data-vscode-theme-id'] })
+
+window.addEventListener('message', (event: MessageEvent<ExtensionMessage>) => {
+  const message = event.data
+  if (!message || typeof message.type !== 'string') return
+  try {
+    switch (message.type) {
+      case 'document': sync.receiveDocument(message); break
+      case 'recovered': recover.disabled = false; pendingActions.length = 0; sync.reset(message.document); break
+      case 'actionFinished': actionInFlight = false; runNextAction(); break
+      case 'accepted': sync.accept(message.sequence, message.version); break
+      case 'rejected': sync.reject(message.sequence, message.error); break
+      case 'flush': sync.flush(message.requestId); break
+      case 'command': command(message.command, message.text); break
+      case 'images':
+        for (const [path, url] of Object.entries(message.urls)) imageUrls.set(path, url)
+        for (const image of mount.querySelectorAll<HTMLImageElement>('img[data-markleaf-path]')) {
+          const path = image.getAttribute('data-markleaf-path')!
+          const url = imageUrls.get(path)
+          if (url && image.getAttribute('src') !== url) image.src = url
+        }
+        break
+      case 'settings':
+        document.documentElement.style.setProperty('--ml-font-size', `${Math.max(10, Math.min(32, message.fontSize))}px`)
+        document.documentElement.style.setProperty('--ml-max-width', `${Math.max(320, Math.min(1600, message.maxWidth))}px`)
+        if (!editor && !initialState?.mode) mode = message.defaultMode
+        break
+      case 'error':
+        recover.disabled = false
+        noticeError = message.message
+        noticeText.textContent = message.message
+        notice.hidden = false
+        break
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    renderingFailed = true
+    editor?.setEditable(false, false)
+    mount.dataset.readOnly = 'true'
+    modeButton.disabled = true
+    noticeError = `加载文档失败：${message}`
+    noticeText.textContent = noticeError
+    status.textContent = '文档加载失败'
+    notice.hidden = false
+    post({ type: 'error', message })
+  }
+})
+window.addEventListener('pagehide', () => {
+  themeObserver.disconnect()
+  editor?.destroy()
+})
+post({ type: 'ready' })

--- a/packages/editor-web/tests/vscode-editor.test.ts
+++ b/packages/editor-web/tests/vscode-editor.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createEditor, getMarkdown, setHostImageResolver, updateEditorMarkdown } from '../src/editor'
+import * as editorModule from '../src/editor'
+import type { ExtensionMessage, WebviewMessage } from '../src/vscode-protocol'
+
+const editors: ReturnType<typeof createEditor>[] = []
+function editor(markdown: string) {
+  const mount = document.createElement('div')
+  document.body.append(mount)
+  const editor = createEditor(mount, markdown, false, { externalHistory: true })
+  editors.push(editor)
+  return editor
+}
+afterEach(() => {
+  editors.splice(0).forEach(editor => editor.destroy())
+  setHostImageResolver()
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('shared editor in a VS Code text host', () => {
+  it('lets the text host own history while retaining native editor history by default', () => {
+    const visual = editor('hello')
+    expect(visual.extensionManager.extensions.some(extension => extension.name === 'undoRedo')).toBe(false)
+    const native = createEditor(document.createElement('div'), 'hello')
+    editors.push(native)
+    expect(native.extensionManager.extensions.some(extension => extension.name === 'undoRedo')).toBe(true)
+  })
+
+  it('applies external updates to the same view without emitting a local document update', () => {
+    const visual = editor('# Title\n\nhello world')
+    const view = visual.view
+    const element = view.dom
+    const changed = vi.fn()
+    visual.on('update', changed)
+    visual.commands.setTextSelection(12)
+    updateEditorMarkdown(visual, '# Title\n\nupdated')
+    expect(visual.view).toBe(view)
+    expect(visual.view.dom).toBe(element)
+    expect(changed).not.toHaveBeenCalled()
+    expect(getMarkdown(visual)).toContain('updated')
+    expect(visual.state.selection.from).toBe(12)
+  })
+
+  it('keeps image source paths in Markdown while displaying host resource URLs', () => {
+    setHostImageResolver(path => `https://webview.example/${encodeURIComponent(path)}`)
+    const visual = editor('![图片](./assets/example%20image.png)')
+    expect(visual.view.dom.querySelector('img')?.src).toContain('https://webview.example/')
+    expect(getMarkdown(visual)).toContain('./assets/example%20image.png')
+    expect(getMarkdown(visual)).not.toContain('webview.example')
+  })
+
+  it('retains code, formulas, front matter and footnotes after an external update and a text edit', () => {
+    const visual = editor('old')
+    updateEditorMarkdown(visual, '---\ntitle: Example\n---\n\n# Title\n\n$x_y + z$\n\n```ts\nconst a = "<b>"\n```\n\nText[^1].\n\n[^1]: A footnote')
+    let headingPosition = -1
+    visual.state.doc.descendants((node, position) => {
+      if (node.type.name === 'heading') headingPosition = position + 1
+    })
+    expect(headingPosition).toBeGreaterThan(0)
+    visual.view.dispatch(visual.state.tr.insertText('New ', headingPosition))
+    const markdown = getMarkdown(visual)
+    expect(markdown).toContain('title: Example')
+    expect(markdown).toContain('# New Title')
+    expect(markdown).toContain('$x_y + z$')
+    expect(markdown).toContain('const a = "<b>"')
+    expect(markdown).toContain('[^1]: A footnote')
+  })
+
+  it('can switch to reading mode without modifying the document', () => {
+    const visual = editor('# Read me')
+    const before = visual.state.doc
+    const changed = vi.fn()
+    visual.on('update', changed)
+    visual.setEditable(false, false)
+    expect(visual.isEditable).toBe(false)
+    visual.setEditable(true, false)
+    expect(visual.state.doc).toBe(before)
+    expect(changed).not.toHaveBeenCalled()
+  })
+
+  it('runs the webview entry through editing, reading, queued undo, source actions and conflict recovery', async () => {
+    document.body.innerHTML = '<div id="toolbar"><button id="mode"></button><button data-action="openSource">源码</button></div><div id="notice"><span id="notice-text"></span><button id="recover"></button></div><main id="editor"></main><span id="sync-status"></span><span id="word-count"></span>'
+    const messages: WebviewMessage[] = []
+    vi.stubGlobal('acquireVsCodeApi', () => ({ postMessage: (message: WebviewMessage) => messages.push(message), getState: () => undefined, setState: () => {} }))
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+    let visual: ReturnType<typeof createEditor> | undefined
+    const create = vi.spyOn(editorModule, 'createEditor').mockImplementation((...args) => {
+      visual = createEditorOriginal(...args)
+      return visual
+    })
+    await import('../src/vscode')
+    const receive = (message: ExtensionMessage) => window.dispatchEvent(new MessageEvent('message', { data: message }))
+    receive({ type: 'document', markdown: '# Title\n\nHello\n', version: 1, writable: true })
+    expect(messages).toEqual([{ type: 'ready' }])
+    const instance = visual!
+    instance.commands.insertContent('Edited ')
+    expect(messages.at(-1)).toMatchObject({ type: 'edit', baseVersion: 1, sequence: 1 })
+    receive({ type: 'accepted', sequence: 1, version: 2 })
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(document.querySelector('#sync-status')?.textContent).toBe('已同步到 VS Code')
+
+    const mode = document.querySelector<HTMLButtonElement>('#mode')!
+    mode.click()
+    expect(instance.isEditable).toBe(false)
+    mode.click()
+    expect(instance.isEditable).toBe(true)
+    expect(messages.filter(message => message.type === 'edit')).toHaveLength(1)
+
+    const undo = () => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, metaKey: true, cancelable: true }))
+    undo(); undo()
+    expect(messages.filter(message => message.type === 'action')).toHaveLength(1)
+    receive({ type: 'document', markdown: '# Title\n\nHello\n', version: 3, writable: true })
+    receive({ type: 'actionFinished' })
+    expect(messages.filter(message => message.type === 'action')).toEqual([{ type: 'action', action: 'undo' }, { type: 'action', action: 'undo' }])
+    receive({ type: 'actionFinished' })
+    document.querySelector<HTMLButtonElement>('[data-action="openSource"]')!.click()
+    expect(messages.at(-1)).toEqual({ type: 'action', action: 'openSource' })
+    receive({ type: 'actionFinished' })
+
+    instance.commands.insertContent('Local draft ')
+    receive({ type: 'document', markdown: 'Source changed', version: 4, writable: true })
+    expect(instance.isEditable).toBe(false)
+    expect(instance.getText()).toContain('Local draft')
+    document.querySelector<HTMLButtonElement>('#recover')!.click()
+    expect(messages.at(-1)).toMatchObject({ type: 'recoverDraft', markdown: expect.stringContaining('Local draft') })
+    receive({ type: 'recovered', document: { type: 'document', markdown: 'Source changed', version: 4, writable: true } })
+    expect(instance.getText()).toBe('Source changed')
+    expect(instance.isEditable).toBe(true)
+    expect(create).toHaveBeenCalledTimes(1)
+    await new Promise(resolve => setTimeout(resolve, 30))
+    window.dispatchEvent(new Event('pagehide'))
+  })
+})
+
+const createEditorOriginal = createEditor

--- a/packages/editor-web/tests/vscode-sync.test.ts
+++ b/packages/editor-web/tests/vscode-sync.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest'
+import { TextDocumentSync } from '../src/vscode-sync'
+import type { DocumentSnapshot, WebviewMessage } from '../src/vscode-protocol'
+import { documentReplacement, normalizeDocumentMarkdown } from '../../../apps/vscode/src/document-edit'
+
+const snapshot = (markdown: string, version = 1): DocumentSnapshot => ({ type: 'document', markdown, version, writable: true })
+function client() {
+  const messages: WebviewMessage[] = []
+  const render = vi.fn((document: DocumentSnapshot) => document.markdown.trimEnd())
+  const sync = new TextDocumentSync({ post: message => messages.push(message), render, status() {} })
+  sync.receiveDocument(snapshot('hello\n'))
+  return { sync, messages, render }
+}
+
+describe('VS Code document synchronization', () => {
+  it('does not write on opening, even when serialization normalizes the source', () => {
+    const { sync, messages } = client()
+    expect(sync.pending).toBe(false)
+    sync.change('hello')
+    expect(messages).toEqual([])
+  })
+
+  it('acknowledges edits without rendering or disturbing the current editor', () => {
+    const { sync, messages, render } = client()
+    sync.change('hello world')
+    expect(messages).toEqual([{ type: 'edit', sequence: 1, baseVersion: 1, markdown: 'hello world' }])
+    sync.accept(1, 2)
+    expect(render).toHaveBeenCalledTimes(1)
+    expect(sync.pending).toBe(false)
+  })
+
+  it('queues the latest typing behind the current edit and uses the acknowledged version', () => {
+    const { sync, messages } = client()
+    sync.change('hello a')
+    sync.change('hello ab')
+    sync.change('hello abc')
+    expect(messages).toHaveLength(1)
+    sync.accept(1, 2)
+    expect(messages.at(-1)).toEqual({ type: 'edit', sequence: 2, baseVersion: 2, markdown: 'hello abc' })
+    sync.accept(2, 3)
+    expect(sync.pending).toBe(false)
+  })
+
+  it('renders source edits and undo without writing them back', () => {
+    const { sync, messages, render } = client()
+    sync.receiveDocument(snapshot('changed from source', 2))
+    sync.receiveDocument(snapshot('hello', 3))
+    expect(render).toHaveBeenCalledTimes(3)
+    expect(sync.markdown).toBe('hello')
+    expect(messages).toEqual([])
+  })
+
+  it('keeps local typing on an external conflict and prevents stale edits from continuing', () => {
+    const { sync, messages, render } = client()
+    sync.change('my draft')
+    sync.change('my complete draft')
+    sync.receiveDocument(snapshot('external change', 2))
+    sync.accept(1, 3)
+    expect(sync.conflict).toBeTruthy()
+    expect(sync.markdown).toBe('my complete draft')
+    expect(render).toHaveBeenCalledTimes(1)
+    expect(messages).toHaveLength(1)
+  })
+
+  it('preserves a rejected edit and fails save flush rather than reporting synchronization', () => {
+    const { sync, messages } = client()
+    sync.change('draft')
+    sync.flush(42)
+    sync.reject(1, 'File is read-only')
+    expect(sync.conflict).toBe('File is read-only')
+    expect(sync.markdown).toBe('draft')
+    expect(messages.at(-1)).toEqual({ type: 'flushed', requestId: 42, success: false })
+  })
+
+  it('submits a committed IME composition as one edit and waits for its acknowledgement before save', () => {
+    const { sync, messages } = client()
+    sync.setComposing(true)
+    sync.change('hello n')
+    sync.change('hello ni')
+    sync.flush(1)
+    expect(messages).toEqual([])
+    sync.change('hello 你')
+    sync.setComposing(false)
+    expect(messages).toEqual([{ type: 'edit', sequence: 1, baseVersion: 1, markdown: 'hello 你' }])
+    sync.accept(1, 2)
+    expect(messages.at(-1)).toEqual({ type: 'flushed', requestId: 1, success: true })
+  })
+
+  it('does not replace a composing editor when a source change arrives', () => {
+    const { sync, render, messages } = client()
+    sync.setComposing(true)
+    sync.receiveDocument(snapshot('external', 2))
+    expect(render).toHaveBeenCalledTimes(1)
+    sync.change('hello 中文')
+    sync.setComposing(false)
+    expect(sync.conflict).toBeTruthy()
+    expect(sync.markdown).toBe('hello 中文')
+    expect(messages).toEqual([])
+  })
+
+  it('can reload the authoritative document after opening the conflict as a draft', () => {
+    const { sync, messages } = client()
+    sync.change('draft')
+    sync.reject(1, 'conflict')
+    sync.reset(snapshot('external', 4))
+    expect(sync.conflict).toBeUndefined()
+    expect(sync.pending).toBe(false)
+    sync.change('external plus local')
+    expect(messages.at(-1)).toMatchObject({ type: 'edit', baseVersion: 4 })
+  })
+
+  it('ignores stale confirmations and stale snapshots', () => {
+    const { sync, messages } = client()
+    sync.receiveDocument(snapshot('newer', 5))
+    sync.receiveDocument(snapshot('old', 2))
+    sync.change('newer edit')
+    sync.accept(100, 99)
+    expect(sync.pending).toBe(true)
+    expect(messages).toHaveLength(1)
+    expect(sync.markdown).toBe('newer edit')
+  })
+
+  it('does not bind a failed render to the newer document version', () => {
+    const { sync, messages, render } = client()
+    render.mockImplementationOnce(() => { throw new Error('Invalid document') })
+    expect(() => sync.receiveDocument(snapshot('cannot render', 2))).toThrow('Invalid document')
+    expect(sync.markdown).toBe('hello')
+    sync.change('old view edit')
+    expect(messages.at(-1)).toMatchObject({ type: 'edit', baseVersion: 1 })
+  })
+})
+
+describe('VS Code text replacements', () => {
+  it.each([
+    ['hello', 'hello world'], ['😀', '😁'], ['a\r\nb', 'a\r\nc'],
+    ['你好，世界', '你好，朋友'], ['abc', ''], ['', 'abc'], ['abc', 'ac'],
+  ])('reconstructs %j as %j without rewriting shared text', (before, after) => {
+    const edit = documentReplacement(before, after)!
+    expect(before.slice(0, edit.start) + edit.text + before.slice(edit.end)).toBe(after)
+    expect(edit.text).not.toMatch(/^[\uDC00-\uDFFF]/)
+  })
+
+  it('retains CRLF and an existing final newline', () => {
+    expect(normalizeDocumentMarkdown('# Title\n\nnew', '# Title\r\n\r\nold\r\n', '\r\n')).toBe('# Title\r\n\r\nnew\r\n')
+    expect(normalizeDocumentMarkdown('new', 'old', '\n')).toBe('new')
+    expect(documentReplacement('same', 'same')).toBeUndefined()
+  })
+})

--- a/packages/editor-web/vite.config.ts
+++ b/packages/editor-web/vite.config.ts
@@ -61,18 +61,22 @@ function katexSelfContainedCss(): Plugin {
   }
 }
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   base: './',
   plugins: [katexWoff2Only(), katexSelfContainedCss()],
   build: {
-    outDir: 'dist',
+    outDir: mode === 'vscode' ? '../../apps/vscode/dist/webview' : 'dist',
     emptyOutDir: true,
     // 发布包不携带调试映射文件；开发调试可通过临时覆盖此项开启。
     sourcemap: false,
     chunkSizeWarningLimit: 550,
+    ...(mode === 'vscode' ? {
+      manifest: true,
+      rollupOptions: { input: 'src/vscode.ts' },
+    } : {}),
   },
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
   },
-})
+}))


### PR DESCRIPTION
MarkLeaf 现在可以作为 VS Code 扩展安装，安装后新打开的 `.md` 和 `.markdown` 文件默认进入 MarkLeaf 渲染视图，支持阅读与可视化编辑。使用 **Ctrl+Shift+V**（macOS 为 **Cmd+Shift+V**）在原生 Markdown 源码和 MarkLeaf 渲染视图之间切换。

扩展复用现有 TypeScript、Tiptap/ProseMirror、KaTeX、Mermaid 和 CSS，通过 `CustomTextEditorProvider` 接入 VS Code，未新增 Electron 依赖或独立桌面运行时。默认打开行为使用 `customEditors.priority: default`，遵循用户已有的编辑器关联；如与其他 Markdown 编辑器同时安装，可通过 **Configure default editor for…** 选择 MarkLeaf。

## 主要改动

- 新增 `apps/vscode` 扩展宿主、文件打开命令、源码并排、主题和文档显示设置。
- 以 VS Code `TextDocument` 管理文档、保存和撤销 / 重做；Webview 串行提交编辑并确认版本，外部修改冲突时保留未同步草稿。
- 新增 VS Code 专用前端入口，复用共享编辑能力，支持阅读 / 编辑切换、常用格式、表格、公式、Mermaid、现有图片和链接。
- 新增 `pnpm build:vscode`、`pnpm package:vscode` 和 VSIX 打包配置，更新根 README 并补充扩展安装与使用说明。
- 原生 Windows/macOS 前端继续使用现有入口和宿主协议。

## 验证

- `pnpm --dir packages/editor-web test tests/vscode-sync.test.ts tests/vscode-editor.test.ts`：25/25 通过。
- `pnpm build:editor-web`：通过。
- `pnpm package:vscode`：类型检查、前端与扩展构建、VSIX 打包通过；包内资源检查通过，产物约 1.66 MiB。
- 使用本机已有 VS Code 1.123.0，在独立配置目录验证最终安装包：扩展激活、普通打开 `.md` / `.markdown` 默认进入 MarkLeaf、源码 / 渲染切换命令、修改并保存、撤销 / 重做、源码并排均通过。默认打开保持源文件内容和未修改状态。自动检查未引入额外桌面运行时。
- 全量前端测试存在 11 项失败；在未修改的 `9b627be` 中复现相同 11 项。涉及格式刷事件、公式、Mermaid 和块手柄事件，另有 jsdom `document.fonts.ready` 未处理错误；本 PR 未修改这些既有断言，也未将全量测试记为通过。
- 用户本地试用反馈基本可用；这不代表完整 GUI、真实输入法或各平台验收完成。

## 测试变更说明（TCR）

新增两份测试文件，沿用现有 Vitest 框架，验证扩展引入的文档同步和 Webview 编辑链路：编辑确认与排队、组合输入、冲突草稿恢复、渲染失败、源码更新、阅读不回写、图片原地址、外部历史和命令队列。默认打开方式由 VS Code 解析扩展清单决定，因此另外使用本地临时扩展宿主脚本验证 `.md` / `.markdown` 的普通打开行为及切回源码。未调整既有测试断言或新增测试框架。

## 使用边界

- 仅打开、阅读和切换模式不会主动重写源文件；实际可视化编辑可能规范化 Markdown 格式，不承诺逐字节保真。
- Ctrl/Cmd+Shift+V 在 Markdown 和 MarkLeaf 场景中用于模式切换，可在键盘快捷方式中重新绑定。
- 每个文件支持一个 MarkLeaf 视图，并可与原生源码并排。首版未包含图片粘贴落盘、PDF、打印和长图导出。
- 当前面向桌面 VS Code；Windows/Linux 和远程工作区尚未实机验证，浏览器版没有扩展入口。
- 本 PR 提供源码和本地 VSIX 打包能力，尚未发布到 Marketplace。
